### PR TITLE
fix(ux): sign-out, mobile nav, responsive grids, shared DashboardLayout

### DIFF
--- a/src/app/dashboard/forms/[id]/page.tsx
+++ b/src/app/dashboard/forms/[id]/page.tsx
@@ -20,8 +20,8 @@ export default async function FormPage({ params }: { params: Promise<{ id: strin
   }));
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <nav className="bg-white border-b border-slate-200 px-6 py-4 flex items-center gap-4">
+    <div>
+      <nav className="bg-white border-b border-slate-100 px-4 sm:px-6 py-3 flex items-center gap-4">
         <Link href="/dashboard" className="text-sm text-slate-500 hover:text-slate-900">
           ← Dashboard
         </Link>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,47 @@
+import { auth, signOut } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <nav className="bg-white border-b border-slate-200 px-4 sm:px-6 py-4 flex items-center justify-between">
+        <Link href="/dashboard" className="text-xl font-bold text-slate-900">
+          Form<span className="text-blue-600">Pilot</span>
+        </Link>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/dashboard/profile"
+            className="text-sm text-slate-600 hover:text-slate-900"
+          >
+            My Profile
+          </Link>
+          <span className="text-sm text-slate-400 hidden sm:block">
+            {session.user.email}
+          </span>
+          <form
+            action={async () => {
+              "use server";
+              await signOut({ redirectTo: "/" });
+            }}
+          >
+            <button
+              type="submit"
+              className="text-sm text-slate-400 hover:text-red-600 transition-colors"
+            >
+              Sign Out
+            </button>
+          </form>
+        </div>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,19 +14,7 @@ export default async function DashboardPage() {
   });
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <nav className="bg-white border-b border-slate-200 px-6 py-4 flex items-center justify-between">
-        <Link href="/" className="text-xl font-bold text-slate-900">
-          Form<span className="text-blue-600">Pilot</span>
-        </Link>
-        <div className="flex items-center gap-4">
-          <Link href="/dashboard/profile" className="text-sm text-slate-600 hover:text-slate-900">
-            My Profile
-          </Link>
-          <span className="text-sm text-slate-400">{session.user.email}</span>
-        </div>
-      </nav>
-
+    <div>
       <main className="max-w-4xl mx-auto px-6 py-10 space-y-8">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold text-slate-900">My Forms</h1>
@@ -86,3 +74,4 @@ export default async function DashboardPage() {
     </div>
   );
 }
+

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -13,8 +13,8 @@ export default async function ProfilePage() {
   });
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <nav className="bg-white border-b border-slate-200 px-6 py-4 flex items-center gap-4">
+    <div>
+      <nav className="bg-white border-b border-slate-100 px-4 sm:px-6 py-3 flex items-center gap-4">
         <Link href="/dashboard" className="text-sm text-slate-500 hover:text-slate-900">
           ← Dashboard
         </Link>

--- a/src/app/dashboard/upload/page.tsx
+++ b/src/app/dashboard/upload/page.tsx
@@ -41,8 +41,8 @@ export default function UploadPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <nav className="bg-white border-b border-slate-200 px-6 py-4 flex items-center gap-4">
+    <div>
+      <nav className="bg-white border-b border-slate-100 px-4 sm:px-6 py-3 flex items-center gap-4">
         <Link href="/dashboard" className="text-sm text-slate-500 hover:text-slate-900">
           ← Dashboard
         </Link>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,13 +1,14 @@
 import { signIn } from "@/lib/auth";
+import Link from "next/link";
 
 export default function LoginPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-slate-50">
       <div className="bg-white rounded-2xl border border-slate-200 p-10 max-w-sm w-full space-y-6 text-center">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900">
+          <Link href="/" className="text-2xl font-bold text-slate-900 hover:opacity-80 transition-opacity">
             Form<span className="text-blue-600">Pilot</span>
-          </h1>
+          </Link>
           <p className="text-slate-500 mt-2 text-sm">Sign in to start filling forms with AI</p>
         </div>
 

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -231,7 +231,7 @@ export default function FormViewer({ form, hasProfile }: Props) {
     <div className="space-y-6">
       {/* Header */}
       <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
-        <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           <div>
             <h1 className="text-xl font-bold text-slate-900">{form.title}</h1>
             <p className="text-sm text-slate-400 mt-1">
@@ -245,7 +245,7 @@ export default function FormViewer({ form, hasProfile }: Props) {
             </p>
           </div>
 
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-col sm:flex-row gap-2">
             {highConfidencePendingCount > 0 && (
               <button
                 onClick={handleAcceptAllHigh}

--- a/src/components/forms/ProfileForm.tsx
+++ b/src/components/forms/ProfileForm.tsx
@@ -86,12 +86,12 @@ export default function ProfileForm({ initialData }: Props) {
     <form onSubmit={handleSubmit} className="space-y-6">
       <section className="space-y-4">
         <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide">Personal</h2>
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <Field label="First Name" value={form.firstName ?? ""} onChange={(v) => set("firstName", v)} required />
           <Field label="Last Name" value={form.lastName ?? ""} onChange={(v) => set("lastName", v)} required />
         </div>
         <Field label="Email" type="email" value={form.email ?? ""} onChange={(v) => set("email", v)} required />
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <Field label="Phone" value={form.phone ?? ""} onChange={(v) => set("phone", v)} />
           <Field label="Date of Birth" type="date" value={form.dateOfBirth ?? ""} onChange={(v) => set("dateOfBirth", v)} />
         </div>
@@ -100,11 +100,11 @@ export default function ProfileForm({ initialData }: Props) {
       <section className="space-y-4">
         <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide">Address</h2>
         <Field label="Street" value={form.address?.street ?? ""} onChange={(v) => setAddress("street", v)} />
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <Field label="City" value={form.address?.city ?? ""} onChange={(v) => setAddress("city", v)} />
           <Field label="State / Province" value={form.address?.state ?? ""} onChange={(v) => setAddress("state", v)} />
         </div>
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <Field label="ZIP / Postal Code" value={form.address?.zip ?? ""} onChange={(v) => setAddress("zip", v)} />
           <Field label="Country" value={form.address?.country ?? ""} onChange={(v) => setAddress("country", v)} />
         </div>
@@ -112,7 +112,7 @@ export default function ProfileForm({ initialData }: Props) {
 
       <section className="space-y-4">
         <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide">Employment</h2>
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <Field label="Employer Name" value={form.employerName ?? ""} onChange={(v) => set("employerName", v)} />
           <Field label="Job Title" value={form.jobTitle ?? ""} onChange={(v) => set("jobTitle", v)} />
         </div>


### PR DESCRIPTION
## What

- Created `src/app/dashboard/layout.tsx` — a shared `DashboardLayout` server component that provides the persistent nav bar for all authenticated pages
- Added a Sign Out button in the nav using NextAuth `signOut` server action, redirects to `/`
- Email in nav hidden on mobile with `hidden sm:block` to prevent overflow at 375px; padding reduced to `px-4 sm:px-6`
- `FormPilot` heading on login page is now a `<Link href="/">` so users can navigate back to landing
- All `grid-cols-2` in `ProfileForm.tsx` changed to `grid-cols-1 sm:grid-cols-2`
- `FormViewer` header uses `flex-col sm:flex-row` so buttons stack on mobile
- Removed duplicated inline nav blocks from dashboard, profile, upload, and forms/[id] pages

## Why

Closes #31

## Acceptance Criteria

- [x] Sign-out button added to dashboard nav (NextAuth signOut server action)
- [x] "FormPilot" on login page is a Link to "/"
- [x] Nav overflow on mobile fixed — email hidden with `hidden sm:block`
- [x] Profile form uses `grid-cols-1 sm:grid-cols-2`
- [x] Form viewer header buttons use `flex-col sm:flex-row`
- [x] Shared DashboardLayout component created, nav duplication eliminated

## Test Plan

1. Sign in via Google OAuth
2. Verify nav shows on all dashboard pages (/, /profile, /upload, /forms/[id])
3. Click Sign Out — should redirect to landing page and require sign-in again
4. Resize to 375px — email should hide, nav should not overflow
5. On `/dashboard/profile` at 375px — form fields should be single column
6. On `/dashboard/forms/[id]` at 375px — Export and Autofill buttons should stack vertically
7. On `/login` — click "FormPilot" heading, should navigate to "/"

@QA-agent please review