### PR TITLE
Guided step-by-step fill mode

### DIFF
--- a/src/app/dashboard/forms/[id]/page.tsx
+++ b/src/app/dashboard/forms/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from "@/lib/auth";
 import { redirect, notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
-import FormViewer from "@/components/forms/FormViewer";
+import FormPageClient from "@/components/forms/FormPageClient";
 import Link from "next/link";
 
 export default async function FormPage({ params }: { params: Promise<{ id: string }> }) {
@@ -30,7 +30,7 @@ export default async function FormPage({ params }: { params: Promise<{ id: strin
       </nav>
 
       <main className="max-w-4xl mx-auto px-6 py-10">
-        <FormViewer form={form} hasProfile={hasProfile} />
+        <FormPageClient form={form} hasProfile={hasProfile} />
       </main>
     </div>
   );

--- a/src/components/forms/FormPageClient.tsx
+++ b/src/components/forms/FormPageClient.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import FormViewer from "./FormViewer";
+import GuidedFillMode from "./GuidedFillMode";
+import type { FormField, FieldState } from "@/lib/ai/analyze-form";
+
+interface FormRecord {
+  id: string;
+  title: string;
+  status: string;
+  fields: unknown;
+}
+
+interface Props {
+  form: FormRecord;
+  hasProfile: boolean;
+}
+
+export default function FormPageClient({ form, hasProfile }: Props) {
+  const [mode, setMode] = useState<"full" | "guided">("full");
+  const [formData, setFormData] = useState(form);
+
+  const fields = formData.fields as FormField[];
+  const initialValues = Object.fromEntries(
+    fields.filter((f) => f.value).map((f) => [f.id, f.value!])
+  );
+  const initialStates = Object.fromEntries(
+    fields.filter((f) => f.fieldState).map((f) => [f.id, f.fieldState!])
+  );
+
+  function handleValuesChange(newValues: Record<string, string>, newStates: Record<string, FieldState>) {
+    // Sync values back to form data so switching modes preserves state
+    const updatedFields = fields.map((f) => ({
+      ...f,
+      value: newValues[f.id] ?? f.value,
+      fieldState: newStates[f.id] ?? f.fieldState,
+    }));
+    setFormData({ ...formData, fields: updatedFields as unknown });
+  }
+
+  if (mode === "guided") {
+    return (
+      <GuidedFillMode
+        formId={form.id}
+        fields={fields}
+        initialValues={initialValues}
+        initialStates={initialStates}
+        hasProfile={hasProfile}
+        onExit={() => setMode("full")}
+        onValuesChange={handleValuesChange}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Guided fill toggle */}
+      <div className="flex justify-end">
+        <button
+          onClick={() => setMode("guided")}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v3.586L7.707 9.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 10.586V7z" clipRule="evenodd" />
+          </svg>
+          Guided Fill Mode
+        </button>
+      </div>
+      <FormViewer form={formData} hasProfile={hasProfile} />
+    </div>
+  );
+}

--- a/src/components/forms/GuidedFillMode.tsx
+++ b/src/components/forms/GuidedFillMode.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import type { FormField, FieldState } from "@/lib/ai/analyze-form";
+
+interface Props {
+  formId: string;
+  fields: FormField[];
+  initialValues: Record<string, string>;
+  initialStates: Record<string, FieldState>;
+  hasProfile: boolean;
+  onExit: () => void;
+  onValuesChange: (values: Record<string, string>, states: Record<string, FieldState>) => void;
+}
+
+// Group fields by category based on profileKey or label patterns
+function groupFields(fields: FormField[]): { name: string; fields: FormField[] }[] {
+  const groups: Record<string, FormField[]> = {};
+
+  for (const field of fields) {
+    let category = "Other";
+    const key = field.profileKey?.toLowerCase() ?? "";
+    const label = field.label.toLowerCase();
+
+    if (
+      key.startsWith("address") ||
+      label.includes("address") ||
+      label.includes("city") ||
+      label.includes("state") ||
+      label.includes("zip") ||
+      label.includes("country")
+    ) {
+      category = "Address";
+    } else if (
+      ["firstname", "lastname", "email", "phone", "dateofbirth"].includes(key) ||
+      label.includes("name") ||
+      label.includes("email") ||
+      label.includes("phone") ||
+      label.includes("birth") ||
+      label.includes("dob")
+    ) {
+      category = "Personal Information";
+    } else if (
+      ["employername", "jobtitle", "annualincome"].includes(key) ||
+      label.includes("employer") ||
+      label.includes("job") ||
+      label.includes("occupation") ||
+      label.includes("income") ||
+      label.includes("salary") ||
+      label.includes("company")
+    ) {
+      category = "Employment";
+    } else if (
+      ["ssn", "passportnumber"].includes(key) ||
+      label.includes("ssn") ||
+      label.includes("social security") ||
+      label.includes("passport") ||
+      label.includes("license") ||
+      label.includes("id number")
+    ) {
+      category = "Identity Documents";
+    }
+
+    if (!groups[category]) groups[category] = [];
+    groups[category].push(field);
+  }
+
+  // Order: Personal → Address → Employment → Identity → Other
+  const order = ["Personal Information", "Address", "Employment", "Identity Documents", "Other"];
+  return order
+    .filter((name) => groups[name]?.length)
+    .map((name) => ({ name, fields: groups[name] }));
+}
+
+export default function GuidedFillMode({
+  formId,
+  fields,
+  initialValues,
+  initialStates,
+  hasProfile,
+  onExit,
+  onValuesChange,
+}: Props) {
+  const groups = groupFields(fields);
+  const totalSteps = groups.length;
+
+  const [currentStep, setCurrentStep] = useState(0);
+  const [values, setValues] = useState<Record<string, string>>(initialValues);
+  const [fieldStates, setFieldStates] = useState<Record<string, FieldState>>(initialStates);
+  const [autofilling, setAutofilling] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const currentGroup = groups[currentStep];
+
+  const scheduleSave = useCallback(
+    (newValues: Record<string, string>, newStates: Record<string, FieldState>) => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      setSaveStatus("saving");
+      saveTimer.current = setTimeout(async () => {
+        try {
+          const allFieldIds = new Set([...Object.keys(newValues), ...Object.keys(newStates)]);
+          const fieldUpdates = Array.from(allFieldIds).map((id) => ({
+            id,
+            ...(id in newValues ? { value: newValues[id] } : {}),
+            ...(id in newStates ? { fieldState: newStates[id] } : {}),
+          }));
+          await fetch(`/api/forms/${formId}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ fields: fieldUpdates, status: "FILLING" }),
+          });
+          setSaveStatus("saved");
+          onValuesChange(newValues, newStates);
+        } catch {
+          setSaveStatus("idle");
+        }
+      }, 500);
+    },
+    [formId, onValuesChange]
+  );
+
+  function handleValueChange(fieldId: string, value: string) {
+    const newValues = { ...values, [fieldId]: value };
+    setValues(newValues);
+    scheduleSave(newValues, fieldStates);
+  }
+
+  function handleAccept(fieldId: string) {
+    const newStates = { ...fieldStates, [fieldId]: "accepted" as FieldState };
+    setFieldStates(newStates);
+    scheduleSave(values, newStates);
+  }
+
+  function handleSkip(fieldId: string) {
+    const newStates = { ...fieldStates, [fieldId]: "rejected" as FieldState };
+    const newValues = { ...values };
+    delete newValues[fieldId];
+    setValues(newValues);
+    setFieldStates(newStates);
+    scheduleSave(newValues, newStates);
+  }
+
+  async function handleAutofill() {
+    setAutofilling(true);
+    try {
+      const res = await fetch(`/api/forms/${formId}/autofill`, { method: "POST" });
+      if (!res.ok) return;
+      const data = await res.json();
+      const newFields: FormField[] = data.fields;
+      const newValues = { ...values };
+      const newStates = { ...fieldStates };
+      for (const f of newFields) {
+        if (f.value && !newStates[f.id]) {
+          newValues[f.id] = f.value;
+          newStates[f.id] = "pending";
+        }
+      }
+      setValues(newValues);
+      setFieldStates(newStates);
+      scheduleSave(newValues, newStates);
+    } finally {
+      setAutofilling(false);
+    }
+  }
+
+  const filledInGroup = currentGroup?.fields.filter((f) => values[f.id]).length ?? 0;
+  const totalInGroup = currentGroup?.fields.length ?? 0;
+  const totalFilled = fields.filter((f) => values[f.id]).length;
+  const overallProgress = fields.length > 0 ? Math.round((totalFilled / fields.length) * 100) : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3">
+              <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 text-sm font-bold">
+                {currentStep + 1}
+              </span>
+              <h2 className="text-lg font-bold text-slate-900">
+                {currentGroup?.name ?? "Complete"}
+              </h2>
+            </div>
+            <p className="text-sm text-slate-500 mt-1">
+              Step {currentStep + 1} of {totalSteps} &middot; {overallProgress}% overall
+              {saveStatus === "saving" && <span className="ml-2 text-slate-400">saving...</span>}
+              {saveStatus === "saved" && <span className="ml-2 text-green-500">saved</span>}
+            </p>
+          </div>
+
+          <div className="flex gap-2">
+            {hasProfile && (
+              <button
+                onClick={handleAutofill}
+                disabled={autofilling}
+                className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              >
+                {autofilling ? "Filling..." : "Autofill"}
+              </button>
+            )}
+            <button
+              onClick={onExit}
+              className="px-3 py-1.5 text-sm border border-slate-200 text-slate-600 rounded-lg hover:bg-slate-50"
+            >
+              Exit Guided Mode
+            </button>
+          </div>
+        </div>
+
+        {/* Step progress dots */}
+        <div className="flex gap-1.5 mt-4">
+          {groups.map((g, i) => (
+            <button
+              key={g.name}
+              onClick={() => setCurrentStep(i)}
+              className={`h-2 rounded-full transition-all ${
+                i === currentStep
+                  ? "bg-blue-500 flex-[2]"
+                  : i < currentStep
+                  ? "bg-green-400 flex-1"
+                  : "bg-slate-200 flex-1"
+              }`}
+              aria-label={`Go to step ${i + 1}: ${g.name}`}
+            />
+          ))}
+        </div>
+
+        {/* Group progress */}
+        <p className="text-xs text-slate-400 mt-2">
+          {filledInGroup}/{totalInGroup} fields completed in this section
+        </p>
+      </div>
+
+      {/* Fields for current step */}
+      <div className="space-y-4">
+        {currentGroup?.fields.map((field) => {
+          const state: FieldState = fieldStates[field.id] ?? "pending";
+          const hasValue = Boolean(values[field.id]);
+          const confidence = field.confidence ?? 0;
+
+          return (
+            <div
+              key={field.id}
+              className={`bg-white rounded-xl border p-6 space-y-4 transition-all ${
+                state === "accepted"
+                  ? "border-green-300 bg-green-50/30"
+                  : state === "rejected"
+                  ? "border-slate-200 opacity-60"
+                  : "border-slate-200"
+              }`}
+            >
+              {/* Field label */}
+              <div className="flex items-center justify-between">
+                <label htmlFor={`guided-${field.id}`} className="text-base font-semibold text-slate-900">
+                  {field.label}
+                  {field.required && <span className="text-red-500 ml-1">*</span>}
+                </label>
+                <span className="text-xs text-slate-400">{field.type}</span>
+              </div>
+
+              {/* Explanation */}
+              <div className="bg-blue-50 rounded-lg p-4 space-y-2">
+                <p className="text-sm text-blue-900">{field.explanation}</p>
+                <p className="text-xs text-blue-700">
+                  <span className="font-medium">Example:</span> {field.example}
+                </p>
+                {field.commonMistakes && (
+                  <p className="text-xs text-amber-600">
+                    <span className="font-medium">Common mistake:</span> {field.commonMistakes}
+                  </p>
+                )}
+              </div>
+
+              {/* Autofill suggestion */}
+              {hasValue && confidence > 0 && state === "pending" && (
+                <div className={`rounded-lg p-3 flex items-center justify-between ${
+                  confidence >= 0.8 ? "bg-green-50 border border-green-200" :
+                  confidence >= 0.5 ? "bg-yellow-50 border border-yellow-200" :
+                  "bg-red-50 border border-red-200"
+                }`}>
+                  <div>
+                    <p className="text-sm font-medium text-slate-700">
+                      Suggested: <span className="text-slate-900">{values[field.id]}</span>
+                    </p>
+                    <p className="text-xs text-slate-500">{Math.round(confidence * 100)}% confidence</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleAccept(field.id)}
+                      className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700"
+                    >
+                      Accept
+                    </button>
+                    <button
+                      onClick={() => handleSkip(field.id)}
+                      className="px-3 py-1.5 text-sm border border-slate-200 text-slate-600 rounded-lg hover:bg-slate-50"
+                    >
+                      Clear
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Input */}
+              {state !== "rejected" && (
+                <input
+                  id={`guided-${field.id}`}
+                  type={field.type === "date" ? "date" : "text"}
+                  value={values[field.id] ?? ""}
+                  onChange={(e) => handleValueChange(field.id, e.target.value)}
+                  disabled={state === "accepted"}
+                  className={`w-full px-4 py-3 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+                    state === "accepted"
+                      ? "border-green-200 bg-green-50 cursor-not-allowed"
+                      : "border-slate-200"
+                  }`}
+                  placeholder={field.example}
+                />
+              )}
+
+              {state === "rejected" && (
+                <div className="flex items-center gap-2">
+                  <input
+                    id={`guided-${field.id}`}
+                    type={field.type === "date" ? "date" : "text"}
+                    value={values[field.id] ?? ""}
+                    onChange={(e) => handleValueChange(field.id, e.target.value)}
+                    className="flex-1 px-4 py-3 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    placeholder="Enter value manually..."
+                  />
+                  <button
+                    onClick={() => {
+                      const newStates = { ...fieldStates };
+                      delete newStates[field.id];
+                      setFieldStates(newStates);
+                      scheduleSave(values, newStates);
+                    }}
+                    className="text-xs text-slate-400 hover:text-slate-600 underline whitespace-nowrap"
+                  >
+                    Undo
+                  </button>
+                </div>
+              )}
+
+              {/* Skip button for unfilled fields */}
+              {!hasValue && state === "pending" && !field.required && (
+                <button
+                  onClick={() => handleSkip(field.id)}
+                  className="text-xs text-slate-400 hover:text-slate-600"
+                >
+                  Skip this field
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between items-center bg-white rounded-xl border border-slate-200 p-4">
+        <button
+          onClick={() => setCurrentStep(Math.max(0, currentStep - 1))}
+          disabled={currentStep === 0}
+          className="px-4 py-2 text-sm border border-slate-200 text-slate-600 rounded-lg hover:bg-slate-50 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          Previous
+        </button>
+
+        <span className="text-sm text-slate-500">
+          {currentStep + 1} / {totalSteps}
+        </span>
+
+        {currentStep < totalSteps - 1 ? (
+          <button
+            onClick={() => setCurrentStep(currentStep + 1)}
+            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            Next Section
+          </button>
+        ) : (
+          <button
+            onClick={onExit}
+            className="px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700"
+          >
+            Finish
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/ai/analyze-form.ts
+++ b/src/lib/ai/analyze-form.ts
@@ -4,7 +4,7 @@ import { buildCacheKey, lookupCacheEntries, storeCacheEntries } from "./field-ca
 
 // Shared Anthropic client singleton
 let _client: Anthropic | null = null;
-function getClient(): Anthropic {
+export function getClient(): Anthropic {
   if (!_client) {
     if (!process.env.ANTHROPIC_API_KEY) {
       throw new Error("ANTHROPIC_API_KEY is not set");
@@ -149,11 +149,17 @@ ${truncatedText}`,
 
     const misses: Array<{ cacheKey: string; data: { explanation: string; example: string; commonMistakes: string; profileKey: string | null } }> = [];
 
-    analysis.fields = analysis.fields.map((field) => {
+    analysis.fields = analysis.fields.map((field): FormField => {
       const key = buildCacheKey(field.label, field.type);
       const hit = cached.get(key);
       if (hit) {
-        return { ...field, ...hit };
+        return {
+          ...field,
+          explanation: hit.explanation,
+          example: hit.example,
+          commonMistakes: hit.commonMistakes,
+          ...(hit.profileKey ? { profileKey: hit.profileKey } : {}),
+        };
       }
       misses.push({
         cacheKey: key,


### PR DESCRIPTION
## Summary
- New `GuidedFillMode` component: walks users through form fields grouped by category (Personal Info → Address → Employment → Identity → Other)
- Each step shows: field label, AI explanation, example, common mistakes, autofill suggestion with accept/skip
- Progress indicator with clickable step dots and section completion tracking
- `FormPageClient` wrapper toggles between full view and guided mode
- State syncs between modes — values persist when switching
- Also fixes type error in field cache overlay from #17

## Test plan
- [ ] "Guided Fill Mode" button appears on form viewer page
- [ ] Clicking it enters guided mode with fields grouped by category
- [ ] Each field shows explanation, example, common mistakes
- [ ] Autofill suggestions show with accept/skip buttons
- [ ] Navigation between steps works (Previous/Next/step dots)
- [ ] Exiting guided mode returns to full form view with values preserved
- [ ] Fields save as user progresses (debounced)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)