### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+.git
+.gitignore
+.env
+.env.*
+.vercel
+.DS_Store
+*.md
+coverage
+out
+build
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# ---- Base ----
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+COPY . .
+
+# ---- Dev ----
+# Usage: docker compose up (runs dev server with hot reload)
+FROM base AS dev
+RUN npx prisma generate
+EXPOSE 3000
+CMD ["npm", "run", "dev"]
+
+# ---- Build ----
+FROM base AS build
+RUN npx prisma generate
+RUN npm run build
+
+# ---- Prod ----
+# NOTE: For a smaller production image, add `output: "standalone"` to
+# next.config.ts and switch CMD to: node .next/standalone/server.js
+FROM node:20-alpine AS prod
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build /app/package.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/next.config.ts ./
+
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  app:
+    build:
+      context: .
+      target: dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - DATABASE_URL=postgresql://formpilot:formpilot@postgres:5432/formpilot
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: formpilot
+      POSTGRES_PASSWORD: formpilot
+      POSTGRES_DB: formpilot
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U formpilot"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile (dev with Prisma + hot reload, prod optimized)
- docker-compose.yml with app + PostgreSQL 16
- .dockerignore for clean build context

Closes #52

## Test plan
- [ ] `docker compose up` starts Next.js dev server + Postgres
- [ ] Prisma migrations run against local Postgres
- [ ] Hot reload works when editing source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)