### PR TITLE
feat(#45): IMAGE SourceType + image preprocessing with sharp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "pdf-parse": "^1.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sharp": "^0.34.5",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -26,6 +27,7 @@
         "@types/pdf-parse": "^1.1.4",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/sharp": "^0.31.1",
         "eslint": "^9",
         "eslint-config-next": "15.2.3",
         "jest": "^30.3.0",
@@ -882,7 +884,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -2539,6 +2540,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/sharp": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-5nWwamN9ZFHXaYEincMSuza8nNfOof8nmO+mcI+Agx1uMUk4/pQnNIcix+9rLPXzKrm1pS34+6WRDbDV0Jn7ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4379,7 +4390,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9161,7 +9171,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9231,7 +9240,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "pdf-parse": "^1.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sharp": "^0.34.5",
     "zod": "^3.24.0"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@types/pdf-parse": "^1.1.4",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/sharp": "^0.31.1",
     "eslint": "^9",
     "eslint-config-next": "15.2.3",
     "jest": "^30.3.0",

--- a/prisma/migrations/20260327110000_add_image_source_type/migration.sql
+++ b/prisma/migrations/20260327110000_add_image_source_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "SourceType" ADD VALUE 'IMAGE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,6 +84,7 @@ enum SourceType {
   WORD
   WEB
   SPREADSHEET
+  IMAGE
 }
 
 enum FormStatus {

--- a/src/__tests__/image-preprocess.test.ts
+++ b/src/__tests__/image-preprocess.test.ts
@@ -1,0 +1,106 @@
+import sharp from "sharp";
+import { preprocessImage } from "@/lib/image/preprocess";
+
+// Helper: create a test image buffer of given dimensions
+async function createTestImage(
+  width: number,
+  height: number,
+  format: "png" | "jpeg" | "webp" = "png"
+): Promise<Buffer> {
+  const channels = 3;
+  const raw = Buffer.alloc(width * height * channels, 128);
+  let pipeline = sharp(raw, { raw: { width, height, channels } });
+
+  if (format === "png") pipeline = pipeline.png();
+  else if (format === "jpeg") pipeline = pipeline.jpeg();
+  else pipeline = pipeline.webp();
+
+  return pipeline.toBuffer();
+}
+
+describe("preprocessImage", () => {
+  it("processes a valid PNG image", async () => {
+    const buffer = await createTestImage(800, 600, "png");
+    const result = await preprocessImage(buffer, "image/png");
+
+    expect(result.mimeType).toBe("image/png");
+    expect(result.base64).toBeTruthy();
+    expect(result.width).toBeLessThanOrEqual(800);
+    expect(result.height).toBeLessThanOrEqual(600);
+  });
+
+  it("processes a valid JPEG image", async () => {
+    const buffer = await createTestImage(800, 600, "jpeg");
+    const result = await preprocessImage(buffer, "image/jpeg");
+
+    expect(result.mimeType).toBe("image/jpeg");
+    expect(result.base64).toBeTruthy();
+  });
+
+  it("processes a valid WEBP image", async () => {
+    const buffer = await createTestImage(800, 600, "webp");
+    const result = await preprocessImage(buffer, "image/webp");
+
+    expect(result.mimeType).toBe("image/webp");
+    expect(result.base64).toBeTruthy();
+  });
+
+  it("rejects images smaller than 400x400", async () => {
+    const buffer = await createTestImage(300, 300);
+
+    await expect(preprocessImage(buffer, "image/png")).rejects.toThrow(
+      "Image is too small to read"
+    );
+  });
+
+  it("rejects images with one dimension below 400", async () => {
+    const buffer = await createTestImage(500, 200);
+
+    await expect(preprocessImage(buffer, "image/png")).rejects.toThrow(
+      "Image is too small to read"
+    );
+  });
+
+  it("resizes images larger than 2048px", async () => {
+    const buffer = await createTestImage(4000, 3000, "jpeg");
+    const result = await preprocessImage(buffer, "image/jpeg");
+
+    expect(result.width).toBeLessThanOrEqual(2048);
+    expect(result.height).toBeLessThanOrEqual(2048);
+  });
+
+  it("does not upscale small valid images", async () => {
+    const buffer = await createTestImage(500, 500, "png");
+    const result = await preprocessImage(buffer, "image/png");
+
+    expect(result.width).toBeLessThanOrEqual(500);
+    expect(result.height).toBeLessThanOrEqual(500);
+  });
+
+  it("converts HEIC to JPEG", async () => {
+    // We can't easily create HEIC in tests, but we can verify the format logic
+    // by passing a regular image with HEIC mime type
+    const buffer = await createTestImage(800, 600, "jpeg");
+    const result = await preprocessImage(buffer, "image/heic");
+
+    expect(result.mimeType).toBe("image/jpeg");
+  });
+
+  it("returns valid base64 string", async () => {
+    const buffer = await createTestImage(800, 600);
+    const result = await preprocessImage(buffer, "image/png");
+
+    // Verify base64 is valid by decoding
+    const decoded = Buffer.from(result.base64, "base64");
+    expect(decoded.length).toBeGreaterThan(0);
+  });
+
+  it("maintains aspect ratio when resizing", async () => {
+    const buffer = await createTestImage(4000, 2000, "jpeg");
+    const result = await preprocessImage(buffer, "image/jpeg");
+
+    // Original ratio is 2:1, output should be close
+    const ratio = result.width / result.height;
+    expect(ratio).toBeCloseTo(2, 0);
+  });
+});

--- a/src/app/api/forms/upload/route.ts
+++ b/src/app/api/forms/upload/route.ts
@@ -35,30 +35,64 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "File too large. Max 10MB." }, { status: 400 });
   }
 
-  const allowedTypes = [
+  const DOC_TYPES = [
     "application/pdf",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   ];
+  const IMAGE_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/heic",
+    "image/heif",
+  ];
+  const allowedTypes = [...DOC_TYPES, ...IMAGE_TYPES];
+
   if (!allowedTypes.includes(file.type)) {
-    return NextResponse.json({ error: "Only PDF and DOCX files are supported." }, { status: 400 });
-  }
-
-  const buffer = Buffer.from(await file.arrayBuffer());
-  const text = await extractTextFromBuffer(buffer, file.type);
-
-  if (!text || text.trim().length < 50) {
     return NextResponse.json(
-      { error: "Could not extract readable text from this file. Is it a scanned image PDF?" },
-      { status: 422 }
+      { error: "Supported formats: PDF, DOCX, PNG, JPEG, WEBP, HEIC." },
+      { status: 400 }
     );
   }
 
-  const analysis = await analyzeFormFields(text);
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const isImage = IMAGE_TYPES.includes(file.type);
 
-  const sourceType =
-    file.type === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-      ? "WORD"
-      : "PDF";
+  let analysis;
+  let sourceType: "PDF" | "WORD" | "IMAGE";
+
+  if (isImage) {
+    // Image path: preprocess → vision analysis (wired in #47)
+    const { preprocessImage } = await import("@/lib/image/preprocess");
+    const processed = await preprocessImage(buffer, file.type);
+
+    // TODO(#47): Replace with analyzeFormFieldsFromImage(processed.base64, processed.mimeType)
+    // For now, return an error until the vision integration is complete
+    return NextResponse.json(
+      { error: "Image upload support is coming soon. Please upload a PDF or DOCX for now." },
+      { status: 422 }
+    );
+
+    // Unreachable until #47 wires vision:
+    // analysis = await analyzeFormFieldsFromImage(processed.base64, processed.mimeType);
+    // sourceType = "IMAGE";
+  } else {
+    // Document path: extract text → analyze
+    const text = await extractTextFromBuffer(buffer, file.type);
+
+    if (!text || text.trim().length < 50) {
+      return NextResponse.json(
+        { error: "Could not extract readable text from this file. Is it a scanned image PDF?" },
+        { status: 422 }
+      );
+    }
+
+    analysis = await analyzeFormFields(text);
+    sourceType =
+      file.type === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ? "WORD"
+        : "PDF";
+  }
 
   const form = await prisma.form.create({
     data: {

--- a/src/lib/image/preprocess.ts
+++ b/src/lib/image/preprocess.ts
@@ -1,0 +1,71 @@
+import sharp from "sharp";
+
+export interface PreprocessedImage {
+  base64: string;
+  mimeType: "image/jpeg" | "image/png" | "image/webp";
+  width: number;
+  height: number;
+}
+
+const MAX_DIMENSION = 2048;
+const MIN_DIMENSION = 400;
+
+const HEIC_TYPES = new Set(["image/heic", "image/heif"]);
+
+export async function preprocessImage(
+  buffer: Buffer,
+  originalMimeType: string
+): Promise<PreprocessedImage> {
+  // Read metadata for dimensions
+  const metadata = await sharp(buffer).metadata();
+  const origWidth = metadata.width ?? 0;
+  const origHeight = metadata.height ?? 0;
+
+  // Validate minimum size
+  if (origWidth < MIN_DIMENSION || origHeight < MIN_DIMENSION) {
+    throw new Error(
+      "Image is too small to read. Please upload a larger or higher-resolution image."
+    );
+  }
+
+  // Start pipeline: auto-rotate using EXIF orientation
+  let pipeline = sharp(buffer).rotate();
+
+  // Resize if needed (fit within MAX_DIMENSION x MAX_DIMENSION)
+  const longestEdge = Math.max(origWidth, origHeight);
+  if (longestEdge > MAX_DIMENSION) {
+    pipeline = pipeline.resize(MAX_DIMENSION, MAX_DIMENSION, {
+      fit: "inside",
+      withoutEnlargement: true,
+    });
+  }
+
+  // Determine output format
+  let outputMimeType: PreprocessedImage["mimeType"];
+
+  if (HEIC_TYPES.has(originalMimeType.toLowerCase())) {
+    // HEIC/HEIF → convert to JPEG (not supported by Claude vision)
+    pipeline = pipeline.jpeg({ quality: 90 });
+    outputMimeType = "image/jpeg";
+  } else if (originalMimeType === "image/png") {
+    pipeline = pipeline.png();
+    outputMimeType = "image/png";
+  } else if (originalMimeType === "image/webp") {
+    pipeline = pipeline.webp({ quality: 90 });
+    outputMimeType = "image/webp";
+  } else {
+    // Default to JPEG for all other types (including image/jpeg)
+    pipeline = pipeline.jpeg({ quality: 90 });
+    outputMimeType = "image/jpeg";
+  }
+
+  const outputBuffer = await pipeline.toBuffer();
+  const outputMetadata = await sharp(outputBuffer).metadata();
+
+  return {
+    base64: outputBuffer.toString("base64"),
+    mimeType: outputMimeType,
+    width: outputMetadata.width ?? origWidth,
+    height: outputMetadata.height ?? origHeight,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `IMAGE` to Prisma `SourceType` enum with migration
- New `src/lib/image/preprocess.ts` with `preprocessImage()`:
  - Auto-rotates using EXIF data
  - Resizes images > 2048px (maintains aspect ratio)
  - Converts HEIC/HEIF → JPEG
  - Validates minimum 400x400 dimensions
- Upload route now accepts PNG, JPEG, WEBP, HEIC MIME types
- Placeholder for vision analysis routing (wired in #47)
- 10 unit tests for preprocessing

Closes #45

## Test plan
- [ ] Run `npx jest src/__tests__/image-preprocess.test.ts` — all 10 tests pass
- [ ] Upload an image file — see "coming soon" message (vision not wired yet)
- [ ] Upload a PDF — existing flow works unchanged
- [ ] Verify schema generates correctly: `npx prisma generate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)