### PR TITLE
Fix broken test imports and wire category detection

### DIFF
--- a/src/__tests__/mocks/index.ts
+++ b/src/__tests__/mocks/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Barrel export for all test mocks.
+ */
+export * from "./mock-claude-responses";
+export * from "./mock-profiles";
+export * from "./mock-form-texts";

--- a/src/__tests__/mocks/mock-claude-responses.ts
+++ b/src/__tests__/mocks/mock-claude-responses.ts
@@ -62,7 +62,7 @@ export const TAX_FORM_ANALYSIS: FormAnalysis = {
       explanation: "Your city, state abbreviation, and ZIP code.",
       example: "Springfield, IL 62704",
       commonMistakes: "Forgetting the ZIP code or using wrong state abbreviation.",
-      profileKey: null,
+      profileKey: undefined,
     },
     {
       id: "multiple_jobs",
@@ -73,7 +73,7 @@ export const TAX_FORM_ANALYSIS: FormAnalysis = {
         "Check this if you hold more than one job or if married filing jointly and spouse also works.",
       example: "Checked",
       commonMistakes: "Not checking this when applicable, leading to under-withholding.",
-      profileKey: null,
+      profileKey: undefined,
     },
     {
       id: "dependents_total",
@@ -83,7 +83,7 @@ export const TAX_FORM_ANALYSIS: FormAnalysis = {
       explanation: "Total dollar amount for dependent credits.",
       example: "4000",
       commonMistakes: "Entering the number of dependents instead of the dollar amount.",
-      profileKey: null,
+      profileKey: undefined,
     },
     {
       id: "signature",
@@ -93,7 +93,7 @@ export const TAX_FORM_ANALYSIS: FormAnalysis = {
       explanation: "Your handwritten or electronic signature certifying the information.",
       example: "Jane M. Doe",
       commonMistakes: "Forgetting to sign the form.",
-      profileKey: null,
+      profileKey: undefined,
     },
     {
       id: "date",
@@ -103,7 +103,7 @@ export const TAX_FORM_ANALYSIS: FormAnalysis = {
       explanation: "The date you are completing this form in MM/DD/YYYY format.",
       example: "03/15/2026",
       commonMistakes: "Using the wrong date format.",
-      profileKey: null,
+      profileKey: undefined,
     },
   ],
   estimatedMinutes: 10,
@@ -122,7 +122,7 @@ export const LEASE_FORM_ANALYSIS: FormAnalysis = {
       explanation: "Full legal name of the tenant.",
       example: "Jane Doe",
       commonMistakes: "Using a nickname.",
-      profileKey: null,
+      profileKey: undefined,
     },
     {
       id: "tenant_email",
@@ -152,7 +152,7 @@ export const LEASE_FORM_ANALYSIS: FormAnalysis = {
       explanation: "Full address of the rental property.",
       example: "456 Oak Ave",
       commonMistakes: "Inconsistent address across documents.",
-      profileKey: null,
+      profileKey: undefined,
     },
     {
       id: "lease_start",
@@ -162,7 +162,7 @@ export const LEASE_FORM_ANALYSIS: FormAnalysis = {
       explanation: "The date the lease begins.",
       example: "04/01/2026",
       commonMistakes: "Confusing move-in date with lease start.",
-      profileKey: null,
+      profileKey: undefined,
     },
     {
       id: "monthly_rent",
@@ -172,7 +172,7 @@ export const LEASE_FORM_ANALYSIS: FormAnalysis = {
       explanation: "Monthly rent amount in dollars.",
       example: "1500",
       commonMistakes: "Not including utilities in the total.",
-      profileKey: null,
+      profileKey: undefined,
     },
   ],
   estimatedMinutes: 15,

--- a/src/__tests__/mocks/mock-form-texts.ts
+++ b/src/__tests__/mocks/mock-form-texts.ts
@@ -1,0 +1,67 @@
+/**
+ * Mock form text content for testing analyzeFormFields.
+ */
+
+/** Realistic W-4 form text (abridged). */
+export const TAX_FORM_W4_TEXT = `Form W-4
+Employee's Withholding Certificate
+Department of the Treasury — Internal Revenue Service
+
+Step 1: Enter Personal Information
+(a) First name and middle initial: _______________
+    Last name: _______________
+(b) Social security number: ___-__-____
+(c) Address: _______________
+    City or town, state, and ZIP code: _______________
+(d) Filing status:
+    [ ] Single or Married filing separately
+    [ ] Married filing jointly
+    [ ] Head of household
+
+Step 2: Multiple Jobs or Spouse Works
+Complete this step if you (1) hold more than one job at a time, or
+(2) are married filing jointly and your spouse also works.
+
+Step 3: Claim Dependents
+If your total income will be $200,000 or less ($400,000 or less if married filing jointly):
+Multiply the number of qualifying children under age 17 by $2,000: $______
+Multiply the number of other dependents by $500: $______
+
+Step 4 (optional): Other Adjustments
+(a) Other income (not from jobs): $______
+(b) Deductions: $______
+(c) Extra withholding: $______
+
+Step 5: Sign Here
+Employee's signature: _______________  Date: ___/___/______`;
+
+/** Text longer than the 50,000 char truncation limit. */
+export const OVERSIZED_TEXT = "A".repeat(60_000);
+
+/** An immigration form sample. */
+export const IMMIGRATION_FORM_TEXT = `Form I-130
+Petition for Alien Relative
+Department of Homeland Security — U.S. Citizenship and Immigration Services
+
+Part 1. Relationship
+I am filing this petition for my:
+[ ] Spouse  [ ] Parent  [ ] Brother/Sister  [ ] Child
+
+Part 2. Information About You (Petitioner)
+1. Full legal name:
+   Family Name (Last Name): _______________
+   Given Name (First Name): _______________
+   Middle Name: _______________
+2. Address: _______________
+3. Date of Birth (mm/dd/yyyy): ___/___/______
+4. Place of Birth (City/Town, State, Country): _______________
+5. A-Number (if any): A_______________
+6. U.S. Social Security Number: ___-__-____
+
+Part 3. Information About Your Relative (Beneficiary)
+1. Full legal name:
+   Family Name (Last Name): _______________
+   Given Name (First Name): _______________
+2. Date of Birth (mm/dd/yyyy): ___/___/______
+3. Country of Birth: _______________
+4. Country of Citizenship: _______________`;

--- a/src/__tests__/mocks/mock-profiles.ts
+++ b/src/__tests__/mocks/mock-profiles.ts
@@ -1,0 +1,34 @@
+/**
+ * Mock user profiles for testing stripSensitiveFields and autofillFields.
+ */
+
+/** A profile with all fields populated, including sensitive ones. */
+export const COMPLETE_PROFILE: Record<string, string> = {
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane.doe@example.com",
+  phone: "(555) 123-4567",
+  address: "123 Main St",
+  city: "Springfield",
+  state: "IL",
+  zip: "62701",
+  dateOfBirth: "1990-05-15",
+  employerName: "Acme Corp",
+  employerAddress: "456 Corp Blvd, Springfield, IL 62702",
+  ssn: "123-45-6789",
+  passportNumber: "X12345678",
+  driverLicense: "D400-1234-5678",
+  bankAccount: "9876543210",
+  routingNumber: "021000021",
+  creditCard: "4111111111111111",
+};
+
+/** A profile with only basic fields — no sensitive data. */
+export const MINIMAL_PROFILE: Record<string, string> = {
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane.doe@example.com",
+};
+
+/** An empty profile. */
+export const EMPTY_PROFILE: Record<string, string> = {};

--- a/src/lib/ai/analyze-form.ts
+++ b/src/lib/ai/analyze-form.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { z } from "zod";
 import { buildCacheKey, lookupCacheEntries, storeCacheEntries } from "./field-cache";
+import { detectCategory, CATEGORY_SYSTEM_PROMPTS } from "./form-categories";
 
 // Shared Anthropic client singleton
 let _client: Anthropic | null = null;
@@ -210,18 +211,24 @@ export async function analyzeFormFields(
   const truncatedText = rawText.slice(0, MAX_TEXT_LENGTH);
   const langInstruction = buildLanguageInstruction(language);
 
+  // Detect category from raw text to use category-specific prompts
+  const category = detectCategory(truncatedText, []);
+  const categoryPrompt = CATEGORY_SYSTEM_PROMPTS[category];
+
   const message = await client.messages.create({
     model: "claude-sonnet-4-6",
     max_tokens: 4096,
     messages: [{
       role: "user",
-      content: `${BASE_ANALYSIS_PROMPT}${langInstruction}\n\nFORM CONTENT:\n${truncatedText}`,
+      content: `${categoryPrompt}\n\n${BASE_ANALYSIS_PROMPT}${langInstruction}\n\nFORM CONTENT:\n${truncatedText}`,
     }],
   });
 
   const content = message.content[0];
   if (content.type !== "text") throw new Error("Unexpected response type");
-  return parseAndCacheAnalysis(content.text, language);
+  const analysis = await parseAndCacheAnalysis(content.text, language);
+  analysis.category = category;
+  return analysis;
 }
 
 export async function analyzeFormFieldsFromImage(


### PR DESCRIPTION
## Summary
- Add barrel `index.ts` export for `src/__tests__/mocks/` directory so `from "./mocks"` imports resolve correctly
- Create missing mock data files: `mock-profiles.ts` (COMPLETE_PROFILE, MINIMAL_PROFILE, EMPTY_PROFILE) and `mock-form-texts.ts` (TAX_FORM_W4_TEXT, OVERSIZED_TEXT, IMMIGRATION_FORM_TEXT)
- Wire `detectCategory` + `CATEGORY_SYSTEM_PROMPTS` into `analyzeFormFields` so category-specific prompts are used and `category` is returned in results
- Fix `null` → `undefined` type mismatch in `mock-claude-responses.ts`

## Test plan
- [x] All 258 tests pass (14 suites, previously 3 suites were broken)
- [x] `npx tsc --noEmit` — zero TypeScript errors (previously 9 errors in mocks)
- [x] `git diff --stat` confirms only expected files changed

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)