### PR TITLE
Expand validation engine with currency, EIN, ITIN, length, date range

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
   testMatch: ["**/__tests__/**/*.test.ts"],
+  testPathIgnorePatterns: ["/node_modules/", "/.claude/"],
   transform: {
     "^.+\\.ts$": ["ts-jest", { tsconfig: { module: "commonjs" } }],
   },

--- a/src/__tests__/mocks/index.ts
+++ b/src/__tests__/mocks/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Barrel export for all test mocks.
+ */
+export * from "./mock-claude-responses";
+export * from "./mock-profiles";
+export * from "./mock-form-texts";

--- a/src/__tests__/mocks/mock-form-texts.ts
+++ b/src/__tests__/mocks/mock-form-texts.ts
@@ -1,0 +1,67 @@
+/**
+ * Mock form text content for testing analyzeFormFields.
+ */
+
+/** Realistic W-4 form text (abridged). */
+export const TAX_FORM_W4_TEXT = `Form W-4
+Employee's Withholding Certificate
+Department of the Treasury — Internal Revenue Service
+
+Step 1: Enter Personal Information
+(a) First name and middle initial: _______________
+    Last name: _______________
+(b) Social security number: ___-__-____
+(c) Address: _______________
+    City or town, state, and ZIP code: _______________
+(d) Filing status:
+    [ ] Single or Married filing separately
+    [ ] Married filing jointly
+    [ ] Head of household
+
+Step 2: Multiple Jobs or Spouse Works
+Complete this step if you (1) hold more than one job at a time, or
+(2) are married filing jointly and your spouse also works.
+
+Step 3: Claim Dependents
+If your total income will be $200,000 or less ($400,000 or less if married filing jointly):
+Multiply the number of qualifying children under age 17 by $2,000: $______
+Multiply the number of other dependents by $500: $______
+
+Step 4 (optional): Other Adjustments
+(a) Other income (not from jobs): $______
+(b) Deductions: $______
+(c) Extra withholding: $______
+
+Step 5: Sign Here
+Employee's signature: _______________  Date: ___/___/______`;
+
+/** Text longer than the 50,000 char truncation limit. */
+export const OVERSIZED_TEXT = "A".repeat(60_000);
+
+/** An immigration form sample. */
+export const IMMIGRATION_FORM_TEXT = `Form I-130
+Petition for Alien Relative
+Department of Homeland Security — U.S. Citizenship and Immigration Services
+
+Part 1. Relationship
+I am filing this petition for my:
+[ ] Spouse  [ ] Parent  [ ] Brother/Sister  [ ] Child
+
+Part 2. Information About You (Petitioner)
+1. Full legal name:
+   Family Name (Last Name): _______________
+   Given Name (First Name): _______________
+   Middle Name: _______________
+2. Address: _______________
+3. Date of Birth (mm/dd/yyyy): ___/___/______
+4. Place of Birth (City/Town, State, Country): _______________
+5. A-Number (if any): A_______________
+6. U.S. Social Security Number: ___-__-____
+
+Part 3. Information About Your Relative (Beneficiary)
+1. Full legal name:
+   Family Name (Last Name): _______________
+   Given Name (First Name): _______________
+2. Date of Birth (mm/dd/yyyy): ___/___/______
+3. Country of Birth: _______________
+4. Country of Citizenship: _______________`;

--- a/src/__tests__/mocks/mock-profiles.ts
+++ b/src/__tests__/mocks/mock-profiles.ts
@@ -1,0 +1,34 @@
+/**
+ * Mock user profiles for testing stripSensitiveFields and autofillFields.
+ */
+
+/** A profile with all fields populated, including sensitive ones. */
+export const COMPLETE_PROFILE: Record<string, string> = {
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane.doe@example.com",
+  phone: "(555) 123-4567",
+  address: "123 Main St",
+  city: "Springfield",
+  state: "IL",
+  zip: "62701",
+  dateOfBirth: "1990-05-15",
+  employerName: "Acme Corp",
+  employerAddress: "456 Corp Blvd, Springfield, IL 62702",
+  ssn: "123-45-6789",
+  passportNumber: "X12345678",
+  driverLicense: "D400-1234-5678",
+  bankAccount: "9876543210",
+  routingNumber: "021000021",
+  creditCard: "4111111111111111",
+};
+
+/** A profile with only basic fields — no sensitive data. */
+export const MINIMAL_PROFILE: Record<string, string> = {
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane.doe@example.com",
+};
+
+/** An empty profile. */
+export const EMPTY_PROFILE: Record<string, string> = {};

--- a/src/__tests__/validate-form.test.ts
+++ b/src/__tests__/validate-form.test.ts
@@ -248,4 +248,167 @@ describe("validateForm", () => {
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].rule).toBe("invalid_format");
   });
+
+  // --- Currency/amount format ---
+
+  it("validates currency — plain number valid", () => {
+    const fields = [makeField({ id: "f1", label: "Annual Income", profileKey: "annualincome" })];
+    const result = validateForm(fields, { f1: "50000" }, {});
+
+    expect(result.errors.filter((e) => e.rule === "invalid_format")).toHaveLength(0);
+  });
+
+  it("validates currency — with dollar sign and commas valid", () => {
+    const fields = [makeField({ id: "f1", label: "Monthly Rent" })];
+    const result = validateForm(fields, { f1: "$1,500.00" }, {});
+
+    expect(result.errors.filter((e) => e.rule === "invalid_format")).toHaveLength(0);
+  });
+
+  it("validates currency — with decimals valid", () => {
+    const fields = [makeField({ id: "f1", label: "Payment Amount" })];
+    const result = validateForm(fields, { f1: "1234.56" }, {});
+
+    expect(result.errors.filter((e) => e.rule === "invalid_format")).toHaveLength(0);
+  });
+
+  it("validates currency — invalid text", () => {
+    const fields = [makeField({ id: "f1", label: "Fee Amount" })];
+    const result = validateForm(fields, { f1: "not a number" }, {});
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule).toBe("invalid_format");
+    expect(result.errors[0].message).toContain("amount");
+  });
+
+  it("validates currency detected by label — salary", () => {
+    const fields = [makeField({ id: "f1", label: "Salary" })];
+    const result = validateForm(fields, { f1: "abc" }, {});
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule).toBe("invalid_format");
+  });
+
+  // --- EIN format ---
+
+  it("validates EIN — valid with dash", () => {
+    const fields = [makeField({ id: "f1", label: "Employer Identification Number (EIN)" })];
+    const result = validateForm(fields, { f1: "12-3456789" }, {});
+
+    expect(result.errors.filter((e) => e.rule === "invalid_format")).toHaveLength(0);
+  });
+
+  it("validates EIN — valid without dash", () => {
+    const fields = [makeField({ id: "f1", label: "EIN" })];
+    const result = validateForm(fields, { f1: "123456789" }, {});
+
+    expect(result.errors.filter((e) => e.rule === "invalid_format")).toHaveLength(0);
+  });
+
+  it("validates EIN — invalid", () => {
+    const fields = [makeField({ id: "f1", label: "EIN" })];
+    const result = validateForm(fields, { f1: "12-34" }, {});
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule).toBe("invalid_format");
+    expect(result.errors[0].message).toContain("EIN");
+  });
+
+  // --- ITIN format ---
+
+  it("validates ITIN — valid", () => {
+    const fields = [makeField({ id: "f1", label: "Individual Taxpayer Identification Number" })];
+    const result = validateForm(fields, { f1: "912-34-5678" }, {});
+
+    expect(result.errors.filter((e) => e.rule === "invalid_format")).toHaveLength(0);
+  });
+
+  it("validates ITIN — invalid (not starting with 9)", () => {
+    const fields = [makeField({ id: "f1", label: "ITIN" })];
+    const result = validateForm(fields, { f1: "123-45-6789" }, {});
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule).toBe("invalid_format");
+    expect(result.errors[0].message).toContain("ITIN");
+  });
+
+  // --- Field length constraints ---
+
+  it("rejects name field exceeding 100 characters", () => {
+    const fields = [makeField({ id: "f1", label: "Full Name" })];
+    const result = validateForm(fields, { f1: "A".repeat(101) }, {});
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain("maximum length");
+  });
+
+  it("accepts name field at 100 characters", () => {
+    const fields = [makeField({ id: "f1", label: "Full Name" })];
+    const result = validateForm(fields, { f1: "A".repeat(100) }, {});
+
+    expect(result.errors.filter((e) => e.message.includes("maximum length"))).toHaveLength(0);
+  });
+
+  it("rejects text field exceeding 500 characters", () => {
+    const fields = [makeField({ id: "f1", label: "Notes", type: "text" })];
+    const result = validateForm(fields, { f1: "A".repeat(501) }, {});
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain("500");
+  });
+
+  it("rejects number field exceeding 20 characters", () => {
+    const fields = [makeField({ id: "f1", label: "Amount", type: "number" })];
+    const result = validateForm(fields, { f1: "1".repeat(21) }, {});
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain("20");
+  });
+
+  // --- Date range validation ---
+
+  it("errors when end date is before start date", () => {
+    const fields = [
+      makeField({ id: "f1", label: "Start Date", type: "date" }),
+      makeField({ id: "f2", label: "End Date", type: "date" }),
+    ];
+    const result = validateForm(fields, { f1: "2026-03-15", f2: "2026-03-10" }, {});
+
+    const rangeErrors = result.errors.filter((e) => e.message.includes("must be after"));
+    expect(rangeErrors).toHaveLength(1);
+    expect(rangeErrors[0].fieldId).toBe("f2");
+  });
+
+  it("passes when end date is after start date", () => {
+    const fields = [
+      makeField({ id: "f1", label: "Start Date", type: "date" }),
+      makeField({ id: "f2", label: "End Date", type: "date" }),
+    ];
+    const result = validateForm(fields, { f1: "2026-03-10", f2: "2026-03-15" }, {});
+
+    const rangeErrors = result.errors.filter((e) => e.message.includes("must be after"));
+    expect(rangeErrors).toHaveLength(0);
+  });
+
+  it("validates date range with US format dates", () => {
+    const fields = [
+      makeField({ id: "f1", label: "Begin Date", type: "date" }),
+      makeField({ id: "f2", label: "Expiration Date", type: "date" }),
+    ];
+    const result = validateForm(fields, { f1: "12/01/2026", f2: "06/01/2026" }, {});
+
+    const rangeErrors = result.errors.filter((e) => e.message.includes("must be after"));
+    expect(rangeErrors).toHaveLength(1);
+  });
+
+  it("skips date range check when only one date is provided", () => {
+    const fields = [
+      makeField({ id: "f1", label: "Start Date", type: "date" }),
+      makeField({ id: "f2", label: "End Date", type: "date" }),
+    ];
+    const result = validateForm(fields, { f1: "2026-03-15" }, {});
+
+    const rangeErrors = result.errors.filter((e) => e.message.includes("must be after"));
+    expect(rangeErrors).toHaveLength(0);
+  });
 });

--- a/src/lib/validation/validate-form.ts
+++ b/src/lib/validation/validate-form.ts
@@ -22,6 +22,9 @@ const SSN4_RE = /^\d{4}$/;
 const SSN_FULL_RE = /^\d{3}-?\d{2}-?\d{4}$/;
 const ZIP_RE = /^\d{5}(-\d{4})?$/;
 const DATE_RE = /^(\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4}|\d{1,2}-\d{1,2}-\d{2,4})$/;
+const CURRENCY_RE = /^\$?\d{1,3}(,\d{3})*(\.\d{1,2})?$|^\d+(\.\d{1,2})?$/;
+const EIN_RE = /^\d{2}-?\d{7}$/;
+const ITIN_RE = /^9\d{2}-?\d{2}-?\d{4}$/;
 
 function validateFieldFormat(field: FormField, value: string): string | null {
   const key = field.profileKey?.toLowerCase() ?? "";
@@ -44,6 +47,16 @@ function validateFieldFormat(field: FormField, value: string): string | null {
     }
   }
 
+  // EIN (Employer Identification Number)
+  if (label.includes("ein") || label.includes("employer identification")) {
+    if (!EIN_RE.test(value)) return "Invalid EIN format. Expected: 12-3456789";
+  }
+
+  // ITIN (Individual Taxpayer Identification Number)
+  if (label.includes("itin") || label.includes("taxpayer identification")) {
+    if (!ITIN_RE.test(value)) return "Invalid ITIN format. Expected: 9XX-XX-XXXX (starts with 9)";
+  }
+
   // ZIP
   if (
     key === "address.zip" ||
@@ -56,6 +69,48 @@ function validateFieldFormat(field: FormField, value: string): string | null {
   // Date
   if (field.type === "date" || key === "dateofbirth" || label.includes("date")) {
     if (!DATE_RE.test(value)) return "Invalid date format. Expected: MM/DD/YYYY or YYYY-MM-DD";
+  }
+
+  // Currency / monetary amount
+  if (
+    key === "annualincome" ||
+    label.includes("income") ||
+    label.includes("salary") ||
+    label.includes("amount") ||
+    label.includes("rent") ||
+    label.includes("payment") ||
+    label.includes("price") ||
+    label.includes("cost") ||
+    label.includes("fee")
+  ) {
+    if (!CURRENCY_RE.test(value.replace(/\s/g, ""))) {
+      return "Invalid amount format. Expected: 1234.56 or $1,234.56";
+    }
+  }
+
+  // Field length constraints
+  const lengthError = validateFieldLength(field, value);
+  if (lengthError) return lengthError;
+
+  return null;
+}
+
+/** Enforce min/max length constraints based on field type and label. */
+function validateFieldLength(field: FormField, value: string): string | null {
+  // Names should be at least 1 char and at most 100
+  const label = field.label.toLowerCase();
+  if (label.includes("name") && value.length > 100) {
+    return `"${field.label}" exceeds maximum length of 100 characters`;
+  }
+
+  // General text fields — cap at 500 chars (prevents accidental pastes)
+  if (field.type === "text" && value.length > 500) {
+    return `"${field.label}" exceeds maximum length of 500 characters`;
+  }
+
+  // Number fields should not exceed reasonable length
+  if (field.type === "number" && value.length > 20) {
+    return `"${field.label}" exceeds maximum length of 20 characters`;
   }
 
   return null;
@@ -133,6 +188,39 @@ export function validateForm(
     }
   }
 
+  // Date range validation: check start/end date pairs
+  const dateFields = fields.filter(
+    (f) => f.type === "date" || f.label.toLowerCase().includes("date")
+  );
+  for (const startField of dateFields) {
+    const startLabel = startField.label.toLowerCase();
+    if (!startLabel.includes("start") && !startLabel.includes("begin") && !startLabel.includes("from")) continue;
+    const startValue = values[startField.id]?.trim();
+    if (!startValue) continue;
+
+    // Find matching end date field
+    const endField = dateFields.find((f) => {
+      const endLabel = f.label.toLowerCase();
+      return f.id !== startField.id &&
+        (endLabel.includes("end") || endLabel.includes("expir") || endLabel.includes("to ") || endLabel.includes("through"));
+    });
+    if (!endField) continue;
+    const endValue = values[endField.id]?.trim();
+    if (!endValue) continue;
+
+    const startDate = parseFlexibleDate(startValue);
+    const endDate = parseFlexibleDate(endValue);
+    if (startDate && endDate && startDate > endDate) {
+      errors.push({
+        fieldId: endField.id,
+        fieldLabel: endField.label,
+        severity: "error",
+        message: `"${endField.label}" must be after "${startField.label}"`,
+        rule: "invalid_format",
+      });
+    }
+  }
+
   const completeness = fields.length > 0 ? Math.round((filledCount / fields.length) * 100) : 100;
 
   return {
@@ -141,4 +229,17 @@ export function validateForm(
     errors,
     warnings,
   };
+}
+
+/** Parse a date string in common formats. Returns null if unparseable. */
+function parseFlexibleDate(value: string): Date | null {
+  // ISO: YYYY-MM-DD
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return new Date(value);
+  // US: MM/DD/YYYY or M/D/YYYY
+  const usMatch = value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/);
+  if (usMatch) {
+    const year = usMatch[3].length === 2 ? 2000 + parseInt(usMatch[3]) : parseInt(usMatch[3]);
+    return new Date(year, parseInt(usMatch[1]) - 1, parseInt(usMatch[2]));
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary
- Add currency/amount validator for income, salary, rent, fee, payment, cost fields
- Add EIN (Employer Identification Number) validator — 12-3456789 format
- Add ITIN (Individual Taxpayer Identification Number) validator — must start with 9
- Add field length constraints: name ≤100, text ≤500, number ≤20 chars
- Add date range validation: start date must be before end date (supports ISO and US formats)
- 16 new tests, 44 total validation tests passing

## Test plan
- [x] All 44 validation tests pass
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [x] Currency accepts: `50000`, `$1,500.00`, `1234.56`; rejects text
- [x] EIN accepts: `12-3456789`, `123456789`; rejects short numbers
- [x] ITIN accepts: `912-34-5678`; rejects non-9-starting numbers
- [x] Date range errors when end < start, passes when end > start
- [x] Length constraints enforce maximums per field type

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)