### PR TITLE
fix: Form index + deprecated config + try/catch on 6 routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  experimental: {
-    serverComponentsExternalPackages: ["pdf-parse", "mammoth"],
-  },
+  serverExternalPackages: ["pdf-parse", "mammoth"],
 };
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,8 @@ model Form {
   updatedAt   DateTime   @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 enum SourceType {

--- a/src/app/api/forms/[id]/apply-template/route.ts
+++ b/src/app/api/forms/[id]/apply-template/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
 import type { FormField } from "@/lib/ai/analyze-form";
 
 /** Normalize a label for fuzzy matching */
@@ -26,58 +27,62 @@ export async function POST(
     return NextResponse.json({ error: "templateId is required" }, { status: 400 });
   }
 
-  // Fetch form and template, verify ownership
-  const [form, template] = await Promise.all([
-    prisma.form.findUnique({ where: { id } }),
-    prisma.formTemplate.findUnique({ where: { id: templateId } }),
-  ]);
+  try {
+    // Fetch form and template, verify ownership
+    const [form, template] = await Promise.all([
+      prisma.form.findUnique({ where: { id } }),
+      prisma.formTemplate.findUnique({ where: { id: templateId } }),
+    ]);
 
-  if (!form || form.userId !== session.user.id) {
-    return NextResponse.json({ error: "Form not found" }, { status: 404 });
-  }
-  if (!template || template.userId !== session.user.id) {
-    return NextResponse.json({ error: "Template not found" }, { status: 404 });
-  }
-
-  const fields = form.fields as unknown as FormField[];
-  const templateData = template.fieldData as Record<string, string>;
-
-  // Build a normalized label → value map from template
-  const templateMap = new Map<string, string>();
-  for (const [label, value] of Object.entries(templateData)) {
-    templateMap.set(normalizeLabel(label), value);
-  }
-
-  // Apply template values to matching fields
-  let applied = 0;
-  const updatedFields = fields.map((field) => {
-    const normalizedLabel = normalizeLabel(field.label);
-    const templateValue = templateMap.get(normalizedLabel);
-
-    if (templateValue && !field.value) {
-      applied++;
-      return {
-        ...field,
-        value: templateValue,
-        confidence: 0.7, // Template match confidence
-        fieldState: "pending" as const,
-      };
+    if (!form || form.userId !== session.user.id) {
+      return NextResponse.json({ error: "Form not found" }, { status: 404 });
     }
-    return field;
-  });
+    if (!template || template.userId !== session.user.id) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    }
 
-  // Save updated fields
-  await prisma.form.update({
-    where: { id },
-    data: {
-      fields: updatedFields as object,
-      status: "FILLING",
-    },
-  });
+    const fields = form.fields as unknown as FormField[];
+    const templateData = template.fieldData as Record<string, string>;
 
-  return NextResponse.json({
-    applied,
-    total: fields.length,
-    fields: updatedFields,
-  });
+    // Build a normalized label → value map from template
+    const templateMap = new Map<string, string>();
+    for (const [label, value] of Object.entries(templateData)) {
+      templateMap.set(normalizeLabel(label), value);
+    }
+
+    // Apply template values to matching fields
+    let applied = 0;
+    const updatedFields = fields.map((field) => {
+      const normalizedLabel = normalizeLabel(field.label);
+      const templateValue = templateMap.get(normalizedLabel);
+
+      if (templateValue && !field.value) {
+        applied++;
+        return {
+          ...field,
+          value: templateValue,
+          confidence: 0.7, // Template match confidence
+          fieldState: "pending" as const,
+        };
+      }
+      return field;
+    });
+
+    // Save updated fields
+    await prisma.form.update({
+      where: { id },
+      data: {
+        fields: updatedFields as object,
+        status: "FILLING",
+      },
+    });
+
+    return NextResponse.json({
+      applied,
+      total: fields.length,
+      fields: updatedFields,
+    });
+  } catch (err) {
+    return handleApiError(err, "POST /api/forms/[id]/apply-template");
+  }
 }

--- a/src/app/api/forms/[id]/route.ts
+++ b/src/app/api/forms/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
 import { z } from "zod";
 
 export async function GET(
@@ -13,13 +14,18 @@ export async function GET(
   }
 
   const { id } = await params;
-  const form = await prisma.form.findUnique({ where: { id } });
 
-  if (!form || form.userId !== session.user.id) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  try {
+    const form = await prisma.form.findUnique({ where: { id } });
+
+    if (!form || form.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ form });
+  } catch (err) {
+    return handleApiError(err, "GET /api/forms/[id]");
   }
-
-  return NextResponse.json({ form });
 }
 
 const updateSchema = z.object({
@@ -45,53 +51,58 @@ export async function PATCH(
   }
 
   const { id } = await params;
-  const form = await prisma.form.findUnique({ where: { id } });
 
-  if (!form || form.userId !== session.user.id) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+  try {
+    const form = await prisma.form.findUnique({ where: { id } });
 
-  const body = await req.json();
-  const parsed = updateSchema.safeParse(body);
+    if (!form || form.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
 
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid data" }, { status: 400 });
-  }
+    const body = await req.json();
+    const parsed = updateSchema.safeParse(body);
 
-  const updateData: Record<string, unknown> = {};
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid data" }, { status: 400 });
+    }
 
-  if (parsed.data.status) {
-    updateData.status = parsed.data.status;
-  }
+    const updateData: Record<string, unknown> = {};
 
-  if (parsed.data.fields) {
-    // Merge new values and fieldState into existing fields
-    const existingFields = form.fields as Array<Record<string, unknown>>;
-    const updates = new Map(parsed.data.fields.map((f) => [f.id, f]));
+    if (parsed.data.status) {
+      updateData.status = parsed.data.status;
+    }
 
-    const mergedFields = existingFields.map((f) => {
-      const update = updates.get(f.id as string);
-      if (update) {
-        const merged: Record<string, unknown> = { ...f };
-        if (update.value !== undefined) merged.value = update.value;
-        if (update.fieldState !== undefined) merged.fieldState = update.fieldState;
-        return merged;
-      }
-      return f;
+    if (parsed.data.fields) {
+      // Merge new values and fieldState into existing fields
+      const existingFields = form.fields as Array<Record<string, unknown>>;
+      const updates = new Map(parsed.data.fields.map((f) => [f.id, f]));
+
+      const mergedFields = existingFields.map((f) => {
+        const update = updates.get(f.id as string);
+        if (update) {
+          const merged: Record<string, unknown> = { ...f };
+          if (update.value !== undefined) merged.value = update.value;
+          if (update.fieldState !== undefined) merged.fieldState = update.fieldState;
+          return merged;
+        }
+        return f;
+      });
+
+      updateData.fields = mergedFields;
+      updateData.filledData = Object.fromEntries(
+        mergedFields
+          .filter((f) => f.value)
+          .map((f) => [f.id, f.value])
+      );
+    }
+
+    const updated = await prisma.form.update({
+      where: { id },
+      data: updateData,
     });
 
-    updateData.fields = mergedFields;
-    updateData.filledData = Object.fromEntries(
-      mergedFields
-        .filter((f) => f.value)
-        .map((f) => [f.id, f.value])
-    );
+    return NextResponse.json({ form: updated });
+  } catch (err) {
+    return handleApiError(err, "PATCH /api/forms/[id]");
   }
-
-  const updated = await prisma.form.update({
-    where: { id },
-    data: updateData,
-  });
-
-  return NextResponse.json({ form: updated });
 }

--- a/src/app/api/forms/[id]/suggestions/route.ts
+++ b/src/app/api/forms/[id]/suggestions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getSuggestionsFromHistory } from "@/lib/ai/suggestion-engine";
+import { handleApiError } from "@/lib/api-error";
 import type { FormField } from "@/lib/ai/analyze-form";
 
 // GET /api/forms/[id]/suggestions — returns history-based suggestions for the form's fields
@@ -16,14 +17,18 @@ export async function GET(
 
   const { id } = await params;
 
-  const form = await prisma.form.findUnique({ where: { id } });
-  if (!form || form.userId !== session.user.id) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  try {
+    const form = await prisma.form.findUnique({ where: { id } });
+    if (!form || form.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const fields = form.fields as unknown as FormField[];
+
+    const suggestions = await getSuggestionsFromHistory(session.user.id, fields);
+
+    return NextResponse.json({ suggestions });
+  } catch (err) {
+    return handleApiError(err, "GET /api/forms/[id]/suggestions");
   }
-
-  const fields = form.fields as unknown as FormField[];
-
-  const suggestions = await getSuggestionsFromHistory(session.user.id, fields);
-
-  return NextResponse.json({ suggestions });
 }

--- a/src/app/api/forms/[id]/validate/route.ts
+++ b/src/app/api/forms/[id]/validate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { validateForm } from "@/lib/validation/validate-form";
+import { handleApiError } from "@/lib/api-error";
 import type { FormField } from "@/lib/ai/analyze-form";
 
 export async function GET(
@@ -14,23 +15,28 @@ export async function GET(
   }
 
   const { id } = await params;
-  const form = await prisma.form.findUnique({ where: { id } });
 
-  if (!form || form.userId !== session.user.id) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  try {
+    const form = await prisma.form.findUnique({ where: { id } });
+
+    if (!form || form.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const fields = form.fields as unknown as FormField[];
+
+    // Build values and states maps from current field data
+    const values: Record<string, string> = {};
+    const fieldStates: Record<string, string> = {};
+    for (const field of fields) {
+      if (field.value) values[field.id] = field.value;
+      if (field.fieldState) fieldStates[field.id] = field.fieldState;
+    }
+
+    const result = validateForm(fields, values, fieldStates);
+
+    return NextResponse.json(result);
+  } catch (err) {
+    return handleApiError(err, "GET /api/forms/[id]/validate");
   }
-
-  const fields = form.fields as unknown as FormField[];
-
-  // Build values and states maps from current field data
-  const values: Record<string, string> = {};
-  const fieldStates: Record<string, string> = {};
-  for (const field of fields) {
-    if (field.value) values[field.id] = field.value;
-    if (field.fieldState) fieldStates[field.id] = field.fieldState;
-  }
-
-  const result = validateForm(fields, values, fieldStates);
-
-  return NextResponse.json(result);
 }

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
 
 // DELETE /api/templates/[id] — delete a template
 export async function DELETE(
@@ -13,13 +14,18 @@ export async function DELETE(
   }
 
   const { id } = await params;
-  const template = await prisma.formTemplate.findUnique({ where: { id } });
 
-  if (!template || template.userId !== session.user.id) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  try {
+    const template = await prisma.formTemplate.findUnique({ where: { id } });
+
+    if (!template || template.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await prisma.formTemplate.delete({ where: { id } });
+
+    return NextResponse.json({ deleted: true });
+  } catch (err) {
+    return handleApiError(err, "DELETE /api/templates/[id]");
   }
-
-  await prisma.formTemplate.delete({ where: { id } });
-
-  return NextResponse.json({ deleted: true });
 }

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
 import type { FormField } from "@/lib/ai/analyze-form";
 
 // Sensitive fields to strip from templates
@@ -15,29 +16,33 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const templates = await prisma.formTemplate.findMany({
-    where: { userId: session.user.id },
-    orderBy: { updatedAt: "desc" },
-    select: {
-      id: true,
-      name: true,
-      category: true,
-      createdAt: true,
-      updatedAt: true,
-      fieldData: true,
-    },
-  });
+  try {
+    const templates = await prisma.formTemplate.findMany({
+      where: { userId: session.user.id },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        category: true,
+        createdAt: true,
+        updatedAt: true,
+        fieldData: true,
+      },
+    });
 
-  // Add field count to each template
-  const result = templates.map((t) => {
-    const fields = t.fieldData as Record<string, string>;
-    return {
-      ...t,
-      fieldCount: Object.keys(fields).length,
-    };
-  });
+    // Add field count to each template
+    const result = templates.map((t) => {
+      const fields = t.fieldData as Record<string, string>;
+      return {
+        ...t,
+        fieldCount: Object.keys(fields).length,
+      };
+    });
 
-  return NextResponse.json(result);
+    return NextResponse.json(result);
+  } catch (err) {
+    return handleApiError(err, "GET /api/templates");
+  }
 }
 
 // POST /api/templates — save a form as a template
@@ -57,40 +62,44 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // Fetch the form and verify ownership
-  const form = await prisma.form.findUnique({ where: { id: formId } });
-  if (!form || form.userId !== session.user.id) {
-    return NextResponse.json({ error: "Form not found" }, { status: 404 });
-  }
-
-  const fields = form.fields as unknown as FormField[];
-  const filledFields = fields.filter((f) => f.value);
-
-  if (filledFields.length === 0) {
-    return NextResponse.json(
-      { error: "No filled fields to save as template" },
-      { status: 400 }
-    );
-  }
-
-  // Build field data map, stripping sensitive values
-  const fieldData: Record<string, string> = {};
-  for (const field of filledFields) {
-    if (field.profileKey && SENSITIVE_KEYS.has(field.profileKey)) {
-      continue; // Skip sensitive fields
+  try {
+    // Fetch the form and verify ownership
+    const form = await prisma.form.findUnique({ where: { id: formId } });
+    if (!form || form.userId !== session.user.id) {
+      return NextResponse.json({ error: "Form not found" }, { status: 404 });
     }
-    fieldData[field.label] = field.value!;
+
+    const fields = form.fields as unknown as FormField[];
+    const filledFields = fields.filter((f) => f.value);
+
+    if (filledFields.length === 0) {
+      return NextResponse.json(
+        { error: "No filled fields to save as template" },
+        { status: 400 }
+      );
+    }
+
+    // Build field data map, stripping sensitive values
+    const fieldData: Record<string, string> = {};
+    for (const field of filledFields) {
+      if (field.profileKey && SENSITIVE_KEYS.has(field.profileKey)) {
+        continue; // Skip sensitive fields
+      }
+      fieldData[field.label] = field.value!;
+    }
+
+    const template = await prisma.formTemplate.create({
+      data: {
+        userId: session.user.id,
+        name: name.trim(),
+        sourceFormId: formId,
+        fieldData,
+        category: (form as Record<string, unknown>).category as string | null ?? null,
+      },
+    });
+
+    return NextResponse.json({ id: template.id }, { status: 201 });
+  } catch (err) {
+    return handleApiError(err, "POST /api/templates");
   }
-
-  const template = await prisma.formTemplate.create({
-    data: {
-      userId: session.user.id,
-      name: name.trim(),
-      sourceFormId: formId,
-      fieldData,
-      category: (form as Record<string, unknown>).category as string | null ?? null,
-    },
-  });
-
-  return NextResponse.json({ id: template.id }, { status: 201 });
 }


### PR DESCRIPTION
## Summary
- Add `@@index([userId])` to Form model — prevents full table scans on the most queried model
- Move `experimental.serverComponentsExternalPackages` → `serverExternalPackages` (Next.js 15+ deprecation fix)
- Wrap 6 API routes in try/catch with `handleApiError` for consistent error responses

Closes #79, closes #80

## Test plan
- [x] `next build` passes
- [x] 258/258 tests pass
- [x] `prisma db push` applies index successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)