### PR TITLE
feat: configurable API URL in Chrome extension

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,4 +1,13 @@
-const API_BASE = "https://formpilot-brown.vercel.app";
+const DEFAULT_API_BASE = "https://formpilot-brown.vercel.app";
+
+async function getApiBase() {
+  try {
+    const result = await chrome.storage.sync.get("apiBase");
+    return result.apiBase || DEFAULT_API_BASE;
+  } catch {
+    return DEFAULT_API_BASE;
+  }
+}
 
 // Open side panel when extension icon is clicked
 chrome.action.onClicked.addListener((tab) => {
@@ -26,6 +35,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 
+  if (message.type === "SET_API_BASE") {
+    chrome.storage.sync.set({ apiBase: message.url })
+      .then(() => sendResponse({ success: true }))
+      .catch((err) => sendResponse({ success: false, error: err.message }));
+    return true;
+  }
+
+  if (message.type === "GET_API_BASE") {
+    getApiBase()
+      .then((url) => sendResponse({ url }))
+      .catch(() => sendResponse({ url: DEFAULT_API_BASE }));
+    return true;
+  }
+
   if (message.type === "GET_AUTH_STATUS") {
     getAuthStatus()
       .then((status) => sendResponse(status))
@@ -36,7 +59,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 async function getAuthStatus() {
   try {
-    const response = await fetch(`${API_BASE}/api/auth/session`, {
+    const apiBase = await getApiBase();
+    const response = await fetch(`${apiBase}/api/auth/session`, {
       credentials: "include",
     });
     const session = await response.json();
@@ -47,7 +71,8 @@ async function getAuthStatus() {
 }
 
 async function analyzeFields(fields, language) {
-  const response = await fetch(`${API_BASE}/api/forms/analyze-web`, {
+  const apiBase = await getApiBase();
+  const response = await fetch(`${apiBase}/api/forms/analyze-web`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -259,7 +259,20 @@
 
   <div id="loginPrompt" class="login-prompt" style="display:none">
     <p>Sign in to FormPilot to use the extension.</p>
-    <p style="margin-top:12px"><a href="https://formpilot-brown.vercel.app/login" target="_blank">Sign In</a></p>
+    <p style="margin-top:12px"><a id="loginLink" href="https://formpilot-brown.vercel.app/login" target="_blank">Sign In</a></p>
+  </div>
+
+  <div style="padding:8px 16px;border-top:1px solid #e2e8f0;">
+    <button id="settingsToggle" style="background:none;border:none;color:#94a3b8;font-size:11px;cursor:pointer;padding:4px 0;">⚙ Settings</button>
+    <div id="settingsPanel" style="display:none;margin-top:8px;">
+      <label style="font-size:11px;color:#64748b;">API URL (dev override)</label>
+      <div style="display:flex;gap:4px;margin-top:4px;">
+        <input id="apiUrlInput" type="text" placeholder="https://formpilot-brown.vercel.app" style="flex:1;font-size:11px;border:1px solid #e2e8f0;border-radius:4px;padding:4px 8px;">
+        <button id="apiUrlSave" style="font-size:11px;padding:4px 8px;background:#3b82f6;color:white;border:none;border-radius:4px;cursor:pointer;">Save</button>
+        <button id="apiUrlReset" style="font-size:11px;padding:4px 8px;background:#f1f5f9;color:#475569;border:none;border-radius:4px;cursor:pointer;">Reset</button>
+      </div>
+      <div id="apiUrlStatus" style="font-size:10px;color:#94a3b8;margin-top:4px;"></div>
+    </div>
   </div>
 
   <script src="sidepanel.js"></script>

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -152,6 +152,54 @@ clearBtn.addEventListener("click", () => {
   analysisResult = [];
 });
 
+// Settings panel
+const settingsToggle = document.getElementById("settingsToggle");
+const settingsPanel = document.getElementById("settingsPanel");
+const apiUrlInput = document.getElementById("apiUrlInput");
+const apiUrlSave = document.getElementById("apiUrlSave");
+const apiUrlReset = document.getElementById("apiUrlReset");
+const apiUrlStatus = document.getElementById("apiUrlStatus");
+const loginLink = document.getElementById("loginLink");
+
+settingsToggle.addEventListener("click", () => {
+  const visible = settingsPanel.style.display !== "none";
+  settingsPanel.style.display = visible ? "none" : "block";
+  if (!visible) {
+    chrome.runtime.sendMessage({ type: "GET_API_BASE" }, (res) => {
+      apiUrlInput.value = res?.url || "";
+      updateLoginLink(res?.url || "");
+    });
+  }
+});
+
+apiUrlSave.addEventListener("click", () => {
+  const url = apiUrlInput.value.trim().replace(/\/$/, "");
+  if (!url) return;
+  chrome.runtime.sendMessage({ type: "SET_API_BASE", url }, (res) => {
+    apiUrlStatus.textContent = res?.success ? "Saved. Reload to apply." : "Failed to save.";
+    updateLoginLink(url);
+    setTimeout(() => { apiUrlStatus.textContent = ""; }, 3000);
+  });
+});
+
+apiUrlReset.addEventListener("click", () => {
+  chrome.storage.sync.remove("apiBase", () => {
+    apiUrlInput.value = "";
+    apiUrlStatus.textContent = "Reset to default. Reload to apply.";
+    updateLoginLink("https://formpilot-brown.vercel.app");
+    setTimeout(() => { apiUrlStatus.textContent = ""; }, 3000);
+  });
+});
+
+function updateLoginLink(baseUrl) {
+  if (loginLink) loginLink.href = `${baseUrl}/login`;
+}
+
+// Load current API URL for login link on startup
+chrome.runtime.sendMessage({ type: "GET_API_BASE" }, (res) => {
+  if (res?.url) updateLoginLink(res.url);
+});
+
 function renderFields(fields) {
   fieldList.innerHTML = "";
 


### PR DESCRIPTION
## Summary
- Extension reads API_BASE from Chrome storage.sync instead of hardcoded constant
- Settings panel in sidepanel: save/reset URL, status feedback
- Login link updates dynamically to match configured URL
- Defaults to production URL when no override set

## Test plan
- [ ] Load extension, open sidepanel — default behavior unchanged
- [ ] Click settings gear, enter localhost URL, save — API calls go to localhost
- [ ] Reset — reverts to production URL
- [ ] Login link matches configured URL

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)