### PR TITLE
fix: image analysis reliability, checkbox in guided mode, image MIME type

### DIFF
--- a/src/app/api/forms/[id]/file/route.ts
+++ b/src/app/api/forms/[id]/file/route.ts
@@ -4,9 +4,16 @@ import { prisma } from "@/lib/prisma";
 
 const MIME_TYPES: Record<string, string> = {
   PDF: "application/pdf",
-  IMAGE: "image/jpeg",
   WORD: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 };
+
+/** Detect image MIME type from magic bytes to avoid serving wrong content-type */
+function detectImageMimeType(buf: Buffer): string {
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return "image/png";
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return "image/jpeg";
+  if (buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46) return "image/webp";
+  return "image/jpeg"; // fallback
+}
 
 export async function GET(
   _req: NextRequest,
@@ -31,9 +38,12 @@ export async function GET(
     return NextResponse.json({ error: "No file data" }, { status: 404 });
   }
 
-  const contentType = MIME_TYPES[form.sourceType] ?? "application/octet-stream";
+  const buf = Buffer.from(form.fileBytes as Buffer);
+  const contentType = form.sourceType === "IMAGE"
+    ? detectImageMimeType(buf)
+    : (MIME_TYPES[form.sourceType] ?? "application/octet-stream");
 
-  return new NextResponse(form.fileBytes, {
+  return new NextResponse(buf, {
     headers: {
       "Content-Type": contentType,
       "Content-Disposition": `inline; filename="${form.title ?? "document"}"`,

--- a/src/components/forms/DocumentImageViewer.tsx
+++ b/src/components/forms/DocumentImageViewer.tsx
@@ -12,9 +12,10 @@ interface Props {
   sourceType: string;
   fields: FormField[];
   activeFieldId: string | null;
+  liveValues?: Record<string, string>;
 }
 
-export default function DocumentImageViewer({ formId, sourceType, fields, activeFieldId }: Props) {
+export default function DocumentImageViewer({ formId, sourceType, fields, activeFieldId, liveValues = {} }: Props) {
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [pageWidth, setPageWidth] = useState<number | null>(null);
@@ -30,9 +31,6 @@ export default function DocumentImageViewer({ formId, sourceType, fields, active
   if (coords?.page && coords.page !== currentPage) {
     setCurrentPage(coords.page);
   }
-
-  const showHighlight =
-    coords != null && coords.page === currentPage && pageWidth != null && pageHeight != null;
 
   // IMAGE sourceType: just render the raw image
   if (sourceType === "IMAGE") {
@@ -111,24 +109,51 @@ export default function DocumentImageViewer({ formId, sourceType, fields, active
               }}
             />
 
-            {/* Field highlight overlay */}
-            {showHighlight && coords && (
-              <div
-                aria-hidden="true"
-                className="absolute pointer-events-none"
-                style={{
-                  left: `${coords.x * 100}%`,
-                  top: `${coords.y * 100}%`,
-                  width: `${coords.w * 100}%`,
-                  height: `${coords.h * 100}%`,
-                  backgroundColor: "rgba(251, 191, 36, 0.35)",
-                  border: "2px solid rgba(217, 119, 6, 0.85)",
-                  borderRadius: "2px",
-                  boxShadow: "0 0 0 3px rgba(251, 191, 36, 0.25)",
-                  animation: "pulse 1.5s ease-in-out infinite",
-                }}
-              />
-            )}
+            {/* Text overlays: show live values for all fields with coordinates on this page */}
+            {fields.map((field) => {
+              const c = field.coordinates;
+              if (!c || c.page !== currentPage) return null;
+              const value = liveValues[field.id];
+              const isActive = field.id === activeFieldId;
+              return (
+                <div
+                  key={field.id}
+                  aria-hidden="true"
+                  className="absolute pointer-events-none overflow-hidden"
+                  style={{
+                    left: `${c.x * 100}%`,
+                    top: `${c.y * 100}%`,
+                    width: `${c.w * 100}%`,
+                    height: `${c.h * 100}%`,
+                    border: isActive ? "2px solid rgba(217, 119, 6, 0.85)" : "none",
+                    backgroundColor: isActive ? "rgba(251, 191, 36, 0.15)" : "transparent",
+                    borderRadius: "2px",
+                    boxShadow: isActive ? "0 0 0 3px rgba(251, 191, 36, 0.2)" : "none",
+                    display: "flex",
+                    alignItems: "center",
+                    paddingLeft: "3px",
+                    paddingRight: "3px",
+                  }}
+                >
+                  {value && (
+                    <span
+                      style={{
+                        fontSize: "clamp(7px, 1.2%, 13px)",
+                        color: "#1e40af",
+                        fontFamily: "Arial, sans-serif",
+                        lineHeight: 1.2,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        width: "100%",
+                      }}
+                    >
+                      {value}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </Document>
       </div>

--- a/src/components/forms/FormPageClient.tsx
+++ b/src/components/forms/FormPageClient.tsx
@@ -40,6 +40,11 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, ha
   const [mode, setMode] = useState<"full" | "guided">("full");
   const [formData, setFormData] = useState(form);
   const [activeFieldId, setActiveFieldId] = useState<string | null>(null);
+  const [liveValues, setLiveValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      (form.fields as FormField[]).filter((f) => f.value).map((f) => [f.id, f.value!])
+    )
+  );
   const [sideBySide, setSideBySide] = useState(() => {
     if (typeof window !== "undefined") {
       return localStorage.getItem("fp-side-by-side") === "true";
@@ -230,6 +235,9 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, ha
               hasFile={hasFile}
               sourceType={sourceType}
               onFieldFocus={setActiveFieldId}
+              onValueChange={(fieldId, value) =>
+                setLiveValues((prev) => ({ ...prev, [fieldId]: value }))
+              }
             />
           </div>
           {/* Right: Document panel — sticky so it stays in view while scrolling fields */}
@@ -247,6 +255,7 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, ha
                 sourceType={sourceType ?? "PDF"}
                 fields={fields}
                 activeFieldId={activeFieldId}
+                liveValues={liveValues}
               />
             </div>
           </div>

--- a/src/components/forms/GuidedFillMode.tsx
+++ b/src/components/forms/GuidedFillMode.tsx
@@ -382,7 +382,33 @@ export default function GuidedFillMode({
               )}
 
               {/* Input */}
-              {state !== "rejected" ? (
+              {field.type === "checkbox" ? (
+                <div className="mt-3 flex items-center gap-3">
+                  <button
+                    id={`guided-${field.id}`}
+                    type="button"
+                    role="checkbox"
+                    aria-checked={values[field.id] === "Checked"}
+                    disabled={state === "accepted"}
+                    onClick={() => {
+                      const next = values[field.id] === "Checked" ? "Unchecked" : "Checked";
+                      handleValueChange(field.id, next);
+                    }}
+                    className={`relative w-12 h-6 rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+                      values[field.id] === "Checked" ? "bg-blue-500" : "bg-slate-200"
+                    } ${state === "accepted" ? "opacity-60 cursor-not-allowed" : "cursor-pointer"}`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform duration-200 ${
+                        values[field.id] === "Checked" ? "translate-x-6" : "translate-x-0"
+                      }`}
+                    />
+                  </button>
+                  <span className="text-sm text-slate-600">
+                    {values[field.id] === "Checked" ? "Checked" : "Unchecked"}
+                  </span>
+                </div>
+              ) : state !== "rejected" ? (
                 <input
                   id={`guided-${field.id}`}
                   type={field.type === "date" ? "date" : "text"}

--- a/src/lib/ai/analyze-form.ts
+++ b/src/lib/ai/analyze-form.ts
@@ -78,6 +78,14 @@ export interface FormAnalysis {
 }
 
 // Zod schemas for validating AI responses
+const coordinatesSchema = z.object({
+  x: z.number().min(0).max(1),
+  y: z.number().min(0).max(1),
+  w: z.number().min(0).max(1),
+  h: z.number().min(0).max(1),
+  page: z.number().int().min(1).default(1),
+}).optional();
+
 const formAnalysisSchema = z.object({
   title: z.string(),
   description: z.string(),
@@ -90,6 +98,7 @@ const formAnalysisSchema = z.object({
     example: z.string(),
     commonMistakes: z.string(),
     profileKey: z.string().nullable().optional(),
+    coordinates: coordinatesSchema,
   })),
   estimatedMinutes: z.number(),
 });
@@ -158,6 +167,45 @@ Return ONLY a valid JSON object (no markdown fences, no extra text) matching thi
       "example": "Example answer",
       "commonMistakes": "What people often get wrong",
       "profileKey": "firstName"
+    }
+  ],
+  "estimatedMinutes": 5
+}`;
+
+/** Prompt for image-based analysis — same as base but also requests bounding box coordinates. */
+const IMAGE_ANALYSIS_PROMPT = `You are a form analysis expert. Look at the form image and extract all fillable fields.
+
+For each field, provide:
+1. A plain-language explanation of what information belongs there
+2. A realistic example answer
+3. Common mistakes people make
+4. The profile data key that could auto-fill it (if applicable)
+5. The bounding box of the fillable input area (NOT the label) as fractions of the image dimensions
+
+Profile keys available: firstName, lastName, email, phone, dateOfBirth, address.street, address.city, address.state, address.zip, address.country, ssn (last 4 only), passportNumber, employerName, jobTitle, annualIncome
+
+IMPORTANT for coordinates: measure the blank input area where the user writes, not the label text.
+- x: left edge of input / image width (0.0 to 1.0)
+- y: top edge of input / image height (0.0 to 1.0)
+- w: input width / image width (0.0 to 1.0)
+- h: input height / image height (0.0 to 1.0)
+- page: always 1 for single-page images
+
+Return ONLY a valid JSON object (no markdown fences, no extra text) matching this schema:
+{
+  "title": "Form title",
+  "description": "What this form is for in 1-2 sentences",
+  "fields": [
+    {
+      "id": "unique_snake_case_id",
+      "label": "Field label as shown on form",
+      "type": "text|date|number|select|checkbox|signature",
+      "required": true,
+      "explanation": "Plain language explanation",
+      "example": "Example answer",
+      "commonMistakes": "What people often get wrong",
+      "profileKey": "firstName",
+      "coordinates": { "x": 0.12, "y": 0.08, "w": 0.45, "h": 0.03, "page": 1 }
     }
   ],
   "estimatedMinutes": 5
@@ -350,18 +398,18 @@ export async function analyzeFormFieldsFromImage(
 ): Promise<FormAnalysis> {
   const langInstruction = buildLanguageInstruction(language);
 
-  // Primary: Groq (free tier) — llama-3.2-11b-vision-preview
-  // Fallback: Claude Haiku (paid) if Groq vision is unavailable
+  // Primary: Claude Haiku (reliable vision)
+  // Fallback: Groq vision (cost-saving, less reliable)
   let responseText: string;
   try {
-    responseText = await analyzeImageWithGroq(base64, mimeType, titleHint, langInstruction);
+    responseText = await analyzeImageWithClaude(base64, mimeType, titleHint, langInstruction);
   } catch (primaryErr) {
-    console.warn("[image-analysis] Groq vision failed, falling back to Claude:", primaryErr instanceof Error ? primaryErr.message : primaryErr);
+    console.warn("[image-analysis] Claude vision failed, trying Groq fallback:", primaryErr instanceof Error ? primaryErr.message : primaryErr);
     try {
-      responseText = await analyzeImageWithClaude(base64, mimeType, titleHint, langInstruction);
-    } catch {
-      // Re-throw the primary error for better UX messaging
-      throw primaryErr;
+      responseText = await analyzeImageWithGroq(base64, mimeType, titleHint, langInstruction);
+    } catch (fallbackErr) {
+      console.error("[image-analysis] Both vision models failed. Claude:", primaryErr instanceof Error ? primaryErr.message : primaryErr, "Groq:", fallbackErr instanceof Error ? fallbackErr.message : fallbackErr);
+      throw new Error("Image analysis failed. Please try again or upload a clearer image.");
     }
   }
 


### PR DESCRIPTION
## Summary
- Claude Haiku is now primary for image form analysis (Groq as cost-saving fallback) — fixes 'AI processing error' on image uploads (#104)
- `GuidedFillMode`: checkbox fields now render as a toggle button, not a text input (#109)
- `file/route`: detect MIME from magic bytes for IMAGE uploads (PNG/JPEG/WebP) instead of always returning `image/jpeg`
- `DocumentImageViewer` + `FormPageClient`: wire `liveValues` for real-time text overlay on PDF pages

## Test plan
- [ ] Upload a JPG/PNG image of a form — should extract fields without error
- [ ] Open a form with a checkbox field in guided fill mode — should show toggle, not text input
- [ ] Upload a PNG form → view document → should serve as `image/png` not `image/jpeg`
- [ ] `npx tsc --noEmit` passes ✅
- [ ] 73 tests pass ✅

Fixes #104, #109
Related: #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)