### PR TITLE
refactor+test: extract annotation helpers, fix pdfDocRef double-assign (#118 #119)

### DIFF
--- a/src/__tests__/annotation-helpers.test.ts
+++ b/src/__tests__/annotation-helpers.test.ts
@@ -1,0 +1,116 @@
+import { normalize, matchAnnotationToField } from "../lib/pdf/annotation-helpers";
+import type { FormField } from "../lib/ai/analyze-form";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeField(id: string, label: string): FormField {
+  return {
+    id,
+    label,
+    type: "text",
+    required: false,
+    explanation: "",
+    example: "",
+    commonMistakes: "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// normalize
+// ---------------------------------------------------------------------------
+
+describe("normalize", () => {
+  it("lowercases the string", () => {
+    expect(normalize("First Name")).toBe("first name");
+  });
+
+  it("strips punctuation characters", () => {
+    expect(normalize("Date of Birth (DOB)")).toBe("date of birth dob");
+  });
+
+  it("collapses multiple spaces into one", () => {
+    expect(normalize("address   line   2")).toBe("address line 2");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(normalize("  email address  ")).toBe("email address");
+  });
+
+  it("preserves digits", () => {
+    expect(normalize("Address Line 2")).toBe("address line 2");
+  });
+
+  it("handles empty string", () => {
+    expect(normalize("")).toBe("");
+  });
+
+  it("handles string with only punctuation", () => {
+    expect(normalize("---")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchAnnotationToField
+// ---------------------------------------------------------------------------
+
+describe("matchAnnotationToField", () => {
+  const fields: FormField[] = [
+    makeField("f1", "First Name"),
+    makeField("f2", "Last Name"),
+    makeField("f3", "Date of Birth"),
+    makeField("f4", "Social Security Number"),
+  ];
+
+  it("returns null when no candidates are provided", () => {
+    expect(matchAnnotationToField({}, fields)).toBeNull();
+  });
+
+  it("returns null when fieldName does not match any field", () => {
+    expect(matchAnnotationToField({ fieldName: "Unknown Field XYZ" }, fields)).toBeNull();
+  });
+
+  it("exact matches by fieldName (case-insensitive)", () => {
+    expect(matchAnnotationToField({ fieldName: "first name" }, fields)).toBe("f1");
+    expect(matchAnnotationToField({ fieldName: "LAST NAME" }, fields)).toBe("f2");
+  });
+
+  it("exact matches by alternativeText when fieldName is absent", () => {
+    expect(matchAnnotationToField({ alternativeText: "Date of Birth" }, fields)).toBe("f3");
+  });
+
+  it("prefers fieldName over alternativeText for exact match", () => {
+    // fieldName matches f1, altText matches f2 — should return f1
+    expect(matchAnnotationToField({ fieldName: "First Name", alternativeText: "Last Name" }, fields)).toBe("f1");
+  });
+
+  it("falls back to alternativeText when fieldName has no match", () => {
+    expect(matchAnnotationToField({ fieldName: "nonexistent", alternativeText: "Last Name" }, fields)).toBe("f2");
+  });
+
+  it("substring match: annotation is substring of field label", () => {
+    // "birth" is contained in "date of birth"
+    expect(matchAnnotationToField({ fieldName: "birth" }, fields)).toBe("f3");
+  });
+
+  it("substring match: field label is substring of annotation", () => {
+    // "first name field" contains "first name"
+    expect(matchAnnotationToField({ fieldName: "first name field" }, fields)).toBe("f1");
+  });
+
+  it("returns null when fields array is empty", () => {
+    expect(matchAnnotationToField({ fieldName: "First Name" }, [])).toBeNull();
+  });
+
+  it("strips punctuation before matching", () => {
+    // "First Name:" should normalize to "first name" and match f1
+    expect(matchAnnotationToField({ fieldName: "First Name:" }, fields)).toBe("f1");
+  });
+
+  it("returns the first matching field when multiple substrings could match", () => {
+    // "name" is a substring of both "First Name" and "Last Name" — returns first match
+    const result = matchAnnotationToField({ fieldName: "name" }, fields);
+    expect(["f1", "f2"]).toContain(result);
+  });
+});

--- a/src/components/forms/DocumentImageViewer.tsx
+++ b/src/components/forms/DocumentImageViewer.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import type { FormField } from "@/lib/ai/analyze-form";
+import { normalize, matchAnnotationToField } from "@/lib/pdf/annotation-helpers";
 
 // PDF.js worker via CDN — no native binaries needed, works on Vercel
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
@@ -17,36 +18,6 @@ interface Props {
   fields: FormField[];
   activeFieldId: string | null;
   liveValues?: Record<string, string>;
-}
-
-/**
- * Normalize text for fuzzy matching: lowercase, collapse whitespace, strip punctuation.
- */
-function normalize(s: string) {
-  return s.toLowerCase().replace(/[^a-z0-9\s]/g, "").replace(/\s+/g, " ").trim();
-}
-
-/**
- * Match a PDF annotation (by fieldName or altText) to one of our FormFields.
- * Returns the matching field id or null.
- */
-function matchAnnotationToField(
-  annot: { fieldName?: string; alternativeText?: string },
-  fields: FormField[]
-): string | null {
-  const candidates = [annot.fieldName, annot.alternativeText].filter(Boolean) as string[];
-  for (const candidate of candidates) {
-    const norm = normalize(candidate);
-    // Exact match first
-    const exact = fields.find((f) => normalize(f.label) === norm);
-    if (exact) return exact.id;
-    // Substring match
-    const sub = fields.find(
-      (f) => normalize(f.label).includes(norm) || norm.includes(normalize(f.label))
-    );
-    if (sub) return sub.id;
-  }
-  return null;
 }
 
 export default function DocumentImageViewer({
@@ -188,11 +159,8 @@ export default function DocumentImageViewer({
           file={fileUrl}
           onLoadSuccess={(doc) => {
             setTotalPages(doc.numPages);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            pdfDocRef.current = (doc as any)._pdfInfo ? doc : doc;
-            // Store raw pdfjs doc for annotation extraction
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            pdfDocRef.current = (doc as any)._transport ? doc : doc;
+            // Store raw pdfjs doc reference for annotation extraction
+            pdfDocRef.current = doc;
           }}
           loading={<Spinner />}
           error={<DocError />}

--- a/src/lib/pdf/annotation-helpers.ts
+++ b/src/lib/pdf/annotation-helpers.ts
@@ -1,0 +1,31 @@
+import type { FormField } from "@/lib/ai/analyze-form";
+
+/**
+ * Normalize text for fuzzy matching: lowercase, collapse whitespace, strip punctuation.
+ */
+export function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9\s]/g, "").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Match a PDF annotation (by fieldName or altText) to one of our FormFields.
+ * Returns the matching field id or null.
+ */
+export function matchAnnotationToField(
+  annot: { fieldName?: string; alternativeText?: string },
+  fields: FormField[]
+): string | null {
+  const candidates = [annot.fieldName, annot.alternativeText].filter(Boolean) as string[];
+  for (const candidate of candidates) {
+    const norm = normalize(candidate);
+    // Exact match first
+    const exact = fields.find((f) => normalize(f.label) === norm);
+    if (exact) return exact.id;
+    // Substring match
+    const sub = fields.find(
+      (f) => normalize(f.label).includes(norm) || norm.includes(normalize(f.label))
+    );
+    if (sub) return sub.id;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Extracted `normalize()` and `matchAnnotationToField()` from `DocumentImageViewer.tsx` into `src/lib/pdf/annotation-helpers.ts` — pure functions are now testable
- Fixed redundant double `pdfDocRef.current =` assignment in `onLoadSuccess`
- 18 unit tests covering both helpers (normalize: lowercase/punctuation/whitespace; matchAnnotationToField: exact/substring/altText/empty/no-match)

## Test plan
- [x] `npx tsc --noEmit` — zero errors ✅
- [x] 314 tests pass ✅ (up from 296)
- [x] Coverage 89.7% → 90.0% lines ✅
- [x] All thresholds pass ✅

Fixes #118, #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)