### PR TITLE
feat: Form Memory — learn from completed forms (#134)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,11 +15,12 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  accounts  Account[]
-  sessions  Session[]
-  profile   Profile?
-  forms     Form[]
-  templates FormTemplate[]
+  accounts   Account[]
+  sessions   Session[]
+  profile    Profile?
+  forms      Form[]
+  templates  FormTemplate[]
+  formMemory FormMemory[]
 }
 
 model Account {
@@ -114,6 +115,25 @@ model FieldCache {
   expiresAt      DateTime
 
   @@index([expiresAt])
+}
+
+// Per-user structured memory extracted from completed forms
+model FormMemory {
+  id           String   @id @default(cuid())
+  userId       String
+  fieldType    String   // name | email | phone | address | employer | passport | tax_id | custom
+  label        String   // Normalized field label (lowercase, stripped punctuation)
+  value        String
+  confidence   Float    @default(1.0)
+  sourceFormId String
+  sourceTitle  String
+  lastUsed     DateTime @default(now())
+  createdAt    DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, label])
+  @@index([userId, fieldType])
 }
 
 // Shareable form templates — strips personal values, preserves form structure + guidance

--- a/src/app/api/forms/[id]/extract-memory/route.ts
+++ b/src/app/api/forms/[id]/extract-memory/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
+import { extractMemoryFromForm } from "@/lib/ai/extract-memory";
+import type { FormField } from "@/lib/ai/analyze-form";
+
+// POST /api/forms/[id]/extract-memory — extract filled values into FormMemory
+// Called automatically when a form is marked COMPLETED
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const form = await prisma.form.findUnique({ where: { id } });
+    if (!form || form.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const fields = form.fields as unknown as FormField[];
+    const upserted = await extractMemoryFromForm(
+      session.user.id,
+      form.id,
+      form.title,
+      fields
+    );
+
+    return NextResponse.json({ upserted });
+  } catch (err) {
+    return handleApiError(err, "POST /api/forms/[id]/extract-memory");
+  }
+}

--- a/src/app/api/forms/[id]/route.ts
+++ b/src/app/api/forms/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { handleApiError } from "@/lib/api-error";
+import { extractMemoryFromForm } from "@/lib/ai/extract-memory";
+import type { FormField } from "@/lib/ai/analyze-form";
 import { z } from "zod";
 
 export async function GET(
@@ -135,6 +137,14 @@ export async function PATCH(
       where: { id },
       data: updateData,
     });
+
+    // When a form reaches COMPLETED, extract memory in the background (non-blocking)
+    if (parsed.data.status === "COMPLETED") {
+      const currentFields = (updated.fields ?? form.fields) as unknown as FormField[];
+      extractMemoryFromForm(session.user.id, id, updated.title, currentFields).catch(
+        () => { /* best-effort, don't block response */ }
+      );
+    }
 
     return NextResponse.json({ form: updated });
   } catch (err) {

--- a/src/app/api/memory/[id]/route.ts
+++ b/src/app/api/memory/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
+
+// DELETE /api/memory/[id] — delete a single memory record
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const record = await prisma.formMemory.findUnique({ where: { id } });
+    if (!record || record.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await prisma.formMemory.delete({ where: { id } });
+    return NextResponse.json({ deleted: true });
+  } catch (err) {
+    return handleApiError(err, "DELETE /api/memory/[id]");
+  }
+}

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
+
+// GET /api/memory — list user's form memory entries
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const records = await prisma.formMemory.findMany({
+      where: { userId: session.user.id },
+      orderBy: { lastUsed: "desc" },
+      select: {
+        id: true,
+        fieldType: true,
+        label: true,
+        value: true,
+        confidence: true,
+        sourceTitle: true,
+        lastUsed: true,
+        createdAt: true,
+      },
+    });
+
+    return NextResponse.json({ records });
+  } catch (err) {
+    return handleApiError(err, "GET /api/memory");
+  }
+}
+
+// DELETE /api/memory — delete all memory for the user
+export async function DELETE() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { count } = await prisma.formMemory.deleteMany({
+      where: { userId: session.user.id },
+    });
+    return NextResponse.json({ deleted: count });
+  } catch (err) {
+    return handleApiError(err, "DELETE /api/memory");
+  }
+}

--- a/src/app/dashboard/memory/page.tsx
+++ b/src/app/dashboard/memory/page.tsx
@@ -1,0 +1,94 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+import FormMemoryClient from "@/components/FormMemoryClient";
+
+export const metadata = { title: "Form Memory — FormPilot" };
+
+const FIELD_TYPE_LABELS: Record<string, string> = {
+  name: "Name",
+  email: "Email",
+  phone: "Phone",
+  address: "Address",
+  employer: "Employment",
+  passport: "Travel / ID",
+  tax_id: "Tax / Finance",
+  custom: "Other",
+};
+
+export default async function MemoryPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const records = await prisma.formMemory.findMany({
+    where: { userId: session.user.id! },
+    orderBy: { lastUsed: "desc" },
+    select: {
+      id: true,
+      fieldType: true,
+      label: true,
+      value: true,
+      confidence: true,
+      sourceTitle: true,
+      lastUsed: true,
+    },
+  });
+
+  // Group by fieldType
+  const grouped: Record<string, typeof records> = {};
+  for (const record of records) {
+    const key = record.fieldType in FIELD_TYPE_LABELS ? record.fieldType : "custom";
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push(record);
+  }
+
+  return (
+    <>
+      {/* Breadcrumb */}
+      <nav className="bg-white border-b border-slate-100 px-4 sm:px-6 py-3">
+        <div className="max-w-2xl mx-auto flex items-center gap-2 text-sm">
+          <Link href="/dashboard" className="text-slate-400 hover:text-slate-700 transition-colors">
+            Dashboard
+          </Link>
+          <svg className="w-4 h-4 text-slate-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+          <span className="font-medium text-slate-900">Form Memory</span>
+        </div>
+      </nav>
+
+      <main className="max-w-2xl mx-auto px-4 sm:px-6 py-8 sm:py-10 space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Form Memory</h1>
+          <p className="text-slate-500 mt-1 text-sm">
+            FormPilot learns from your completed forms. These are the values it remembers for future autofill suggestions.
+          </p>
+        </div>
+
+        {records.length === 0 ? (
+          <div className="bg-white rounded-2xl border border-slate-200 p-10 text-center space-y-3">
+            <div className="mx-auto w-12 h-12 rounded-xl bg-blue-50 flex items-center justify-center">
+              <svg className="w-6 h-6 text-blue-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+              </svg>
+            </div>
+            <p className="font-medium text-slate-900">No memory yet</p>
+            <p className="text-sm text-slate-500 max-w-xs mx-auto">
+              Complete a form to start building your memory. FormPilot will remember your answers for next time.
+            </p>
+            <Link href="/dashboard/upload" className="inline-flex items-center gap-1.5 mt-2 text-sm text-blue-600 hover:underline font-medium">
+              Upload a form →
+            </Link>
+          </div>
+        ) : (
+          <FormMemoryClient
+            records={records}
+            grouped={grouped}
+            fieldTypeLabels={FIELD_TYPE_LABELS}
+          />
+        )}
+      </main>
+    </>
+  );
+}

--- a/src/components/DashboardNav.tsx
+++ b/src/components/DashboardNav.tsx
@@ -43,6 +43,15 @@ const NAV_ITEMS = [
     ),
   },
   {
+    href: "/dashboard/memory",
+    label: "Memory",
+    icon: (
+      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+      </svg>
+    ),
+  },
+  {
     href: "/dashboard/extension",
     label: "Extension",
     icon: (

--- a/src/components/FormMemoryClient.tsx
+++ b/src/components/FormMemoryClient.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+
+interface MemoryRecord {
+  id: string;
+  fieldType: string;
+  label: string;
+  value: string;
+  confidence: number;
+  sourceTitle: string;
+  lastUsed: Date;
+}
+
+interface Props {
+  records: MemoryRecord[];
+  grouped: Record<string, MemoryRecord[]>;
+  fieldTypeLabels: Record<string, string>;
+}
+
+function formatDate(date: Date): string {
+  return new Date(date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export default function FormMemoryClient({ records, grouped, fieldTypeLabels }: Props) {
+  const [localGrouped, setLocalGrouped] = useState(grouped);
+  const [clearing, setClearing] = useState(false);
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
+  const totalCount = Object.values(localGrouped).reduce((sum, arr) => sum + arr.length, 0);
+
+  async function deleteRecord(id: string) {
+    setDeletingIds((prev) => new Set(prev).add(id));
+    try {
+      const res = await fetch(`/api/memory/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed");
+      setLocalGrouped((prev) => {
+        const next = { ...prev };
+        for (const key of Object.keys(next)) {
+          next[key] = next[key].filter((r) => r.id !== id);
+          if (next[key].length === 0) delete next[key];
+        }
+        return next;
+      });
+    } catch {
+      alert("Failed to delete memory record");
+    } finally {
+      setDeletingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    }
+  }
+
+  async function clearAll() {
+    if (!window.confirm(`Delete all ${totalCount} memory records? This cannot be undone.`)) return;
+    setClearing(true);
+    try {
+      const res = await fetch("/api/memory", { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed");
+      setLocalGrouped({});
+    } catch {
+      alert("Failed to clear memory");
+    } finally {
+      setClearing(false);
+    }
+  }
+
+  if (totalCount === 0) {
+    return (
+      <div className="text-center py-8 text-sm text-slate-400">
+        All memory records deleted.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-slate-500">{totalCount} remembered values</p>
+        <button
+          onClick={clearAll}
+          disabled={clearing}
+          className="text-sm text-red-500 hover:text-red-700 transition-colors disabled:opacity-50"
+        >
+          {clearing ? "Clearing…" : "Clear all memory"}
+        </button>
+      </div>
+
+      {Object.entries(localGrouped).map(([type, typeRecords]) => (
+        <div key={type} className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+          <div className="px-4 py-3 bg-slate-50 border-b border-slate-100">
+            <h2 className="text-sm font-semibold text-slate-700">
+              {fieldTypeLabels[type] ?? "Other"}
+            </h2>
+          </div>
+          <ul className="divide-y divide-slate-100">
+            {typeRecords.map((record) => (
+              <li key={record.id} className="flex items-center gap-3 px-4 py-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-slate-400 uppercase tracking-wide">{record.label}</span>
+                  </div>
+                  <p className="text-sm font-medium text-slate-900 truncate mt-0.5">{record.value}</p>
+                  <p className="text-xs text-slate-400 mt-0.5">
+                    From <span className="text-slate-500">{record.sourceTitle}</span> · {formatDate(record.lastUsed)}
+                  </p>
+                </div>
+                <button
+                  onClick={() => deleteRecord(record.id)}
+                  disabled={deletingIds.has(record.id)}
+                  className="shrink-0 p-1.5 text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50"
+                  aria-label={`Delete memory for ${record.label}`}
+                >
+                  {deletingIds.has(record.id) ? (
+                    <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+                      <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="3 6 5 6 21 6" />
+                      <path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6" />
+                    </svg>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -91,7 +91,7 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   const [titleDraft, setTitleDraft] = useState(form.title);
   // per-field AI suggestions
   const [suggestingFields, setSuggestingFields] = useState<Set<string>>(new Set());
-  const [fieldSuggestions, setFieldSuggestions] = useState<Record<string, { value: string; source: string } | null>>({});
+  const [fieldSuggestions, setFieldSuggestions] = useState<Record<string, { value: string; source: string; sourceType?: "memory" | "history" } | null>>({});
   // keyboard navigation for unanswered fields
   const [currentUnansweredIndex, setCurrentUnansweredIndex] = useState(0);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -176,7 +176,7 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
         body: JSON.stringify({ fieldId }),
       });
       if (!res.ok) throw new Error("Request failed");
-      const data = await res.json() as { suggestion: { value: string; source: string } | null };
+      const data = await res.json() as { suggestion: { value: string; source: string; sourceType?: "memory" | "history" } | null };
       setFieldSuggestions((prev) => ({ ...prev, [fieldId]: data.suggestion }));
     } catch {
       setFieldSuggestions((prev) => ({ ...prev, [fieldId]: null }));
@@ -1060,7 +1060,7 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                   </div>
                 </div>
 
-                {/* AI suggestion callout */}
+                {/* Suggestion callout */}
                 {field.id in fieldSuggestions && (
                   <div className={`rounded-xl border px-4 py-3 flex items-start justify-between gap-3 ${
                     fieldSuggestions[field.id]
@@ -1070,7 +1070,15 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                     {fieldSuggestions[field.id] ? (
                       <>
                         <div className="min-w-0">
-                          <p className="text-xs text-violet-600 font-medium mb-1">Suggested value</p>
+                          <div className="flex items-center gap-1.5 mb-1">
+                            {fieldSuggestions[field.id]!.sourceType === "memory" ? (
+                              <span className="text-xs font-medium text-emerald-700 bg-emerald-50 border border-emerald-200 px-1.5 py-0.5 rounded-full">
+                                From memory
+                              </span>
+                            ) : (
+                              <span className="text-xs font-medium text-violet-700">Suggested value</span>
+                            )}
+                          </div>
                           <p className="text-sm text-slate-800 font-medium truncate">{fieldSuggestions[field.id]!.value}</p>
                           <p className="text-xs text-slate-400 mt-0.5">From: {fieldSuggestions[field.id]!.source}</p>
                         </div>

--- a/src/lib/ai/extract-memory.ts
+++ b/src/lib/ai/extract-memory.ts
@@ -1,0 +1,90 @@
+import { prisma } from "@/lib/prisma";
+import type { FormField } from "@/lib/ai/analyze-form";
+
+// Sensitive labels — never store in memory
+const SENSITIVE_LABELS = new Set([
+  "ssn", "socialsecuritynumber", "passportnumber", "driverlicense", "driverslicense",
+  "bankaccount", "routingnumber", "creditcard", "creditcardnumber", "taxid", "ein", "itin",
+]);
+
+// Field type taxonomy based on profileKey or label keywords
+const FIELD_TYPE_MAP: Record<string, string> = {
+  firstName: "name", lastName: "name", fullName: "name", name: "name",
+  email: "email", emailAddress: "email",
+  phone: "phone", phoneNumber: "phone", mobile: "phone", cellPhone: "phone",
+  address: "address", streetAddress: "address", city: "address", state: "address",
+  zipCode: "address", postalCode: "address", country: "address",
+  employer: "employer", companyName: "employer", employerName: "employer", occupation: "employer",
+  jobTitle: "employer", workAddress: "employer",
+  passportNumber: "passport", passportIssuedDate: "passport", passportExpiry: "passport",
+  nationality: "passport", countryOfBirth: "passport",
+};
+
+const LABEL_KEYWORD_TYPES: Array<[RegExp, string]> = [
+  [/email/i, "email"],
+  [/phone|mobile|cell|tel/i, "phone"],
+  [/address|street|city|state|zip|postal|country/i, "address"],
+  [/employer|company|organization|employer name|job title|occupation/i, "employer"],
+  [/passport/i, "passport"],
+  [/name/i, "name"],
+];
+
+function classifyFieldType(field: FormField): string {
+  if (field.profileKey && FIELD_TYPE_MAP[field.profileKey]) {
+    return FIELD_TYPE_MAP[field.profileKey];
+  }
+  for (const [pattern, type] of LABEL_KEYWORD_TYPES) {
+    if (pattern.test(field.label)) return type;
+  }
+  return "custom";
+}
+
+function normalizeLabel(label: string): string {
+  return label.toLowerCase().trim().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Extract field→value pairs from a completed form and upsert them to FormMemory.
+ * Sensitive fields are skipped. Called after a form reaches COMPLETED status.
+ */
+export async function extractMemoryFromForm(
+  userId: string,
+  formId: string,
+  formTitle: string,
+  fields: FormField[]
+): Promise<number> {
+  const filledFields = fields.filter(
+    (f) => f.value && f.value.trim() && !SENSITIVE_LABELS.has(normalizeLabel(f.label))
+  );
+
+  if (filledFields.length === 0) return 0;
+
+  let upserted = 0;
+  for (const field of filledFields) {
+    const label = normalizeLabel(field.label);
+    const fieldType = classifyFieldType(field);
+
+    await prisma.formMemory.upsert({
+      where: { userId_label: { userId, label } },
+      update: {
+        value: field.value!.trim(),
+        sourceFormId: formId,
+        sourceTitle: formTitle,
+        lastUsed: new Date(),
+        fieldType,
+      },
+      create: {
+        userId,
+        label,
+        fieldType,
+        value: field.value!.trim(),
+        confidence: 1.0,
+        sourceFormId: formId,
+        sourceTitle: formTitle,
+      },
+    });
+    upserted++;
+  }
+
+  return upserted;
+}

--- a/src/lib/ai/suggestion-engine.ts
+++ b/src/lib/ai/suggestion-engine.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import type { FormField } from "@/lib/ai/analyze-form";
 
-// Sensitive profile keys — never suggest these from history
+// Sensitive profile keys — never suggest these from history or memory
 const SENSITIVE_LABELS = new Set([
   "ssn",
   "socialsecuritynumber",
@@ -21,7 +21,8 @@ export interface FieldSuggestion {
   fieldId: string;
   value: string;
   confidence: number;
-  source: string; // Title of the form it came from
+  source: string; // Form title or "Form Memory"
+  sourceType: "memory" | "history";
 }
 
 /** Normalize a label for fuzzy matching: lowercase, strip punctuation/spaces */
@@ -35,13 +36,8 @@ function isSensitiveLabel(normalizedLabel: string): boolean {
 }
 
 /**
- * Query up to 20 most recent COMPLETED or FILLING forms for a user and return
- * history-based suggestions for the given current form fields.
- *
- * - Field matching uses normalized label comparison (case-insensitive, punctuation-stripped).
- * - Returns the most recent non-empty value per field label.
- * - Sensitive labels are excluded.
- * - Confidence is fixed at 0.6.
+ * Query FormMemory (structured per-user memory store) first at confidence >= 0.8.
+ * Fall back to scanning recent form history for unmatched fields.
  */
 export async function getSuggestionsFromHistory(
   userId: string,
@@ -60,7 +56,42 @@ export async function getSuggestionsFromHistory(
     return [];
   }
 
-  // Query past forms — limit 20, most recent first
+  const suggestions: FieldSuggestion[] = [];
+  const coveredLabels = new Set<string>();
+
+  // --- Step 1: Query FormMemory (structured, high-confidence) ---
+  const memoryRecords = await prisma.formMemory.findMany({
+    where: {
+      userId,
+      label: { in: Array.from(labelToFieldId.keys()) },
+      confidence: { gte: 0.8 },
+    },
+    orderBy: { lastUsed: "desc" },
+  });
+
+  for (const record of memoryRecords) {
+    const fieldId = labelToFieldId.get(record.label);
+    if (!fieldId) continue;
+
+    suggestions.push({
+      fieldId,
+      value: record.value,
+      confidence: record.confidence,
+      source: record.sourceTitle,
+      sourceType: "memory",
+    });
+    coveredLabels.add(record.label);
+  }
+
+  // --- Step 2: Fall back to history scan for unmatched fields ---
+  const remainingLabels = new Set(
+    Array.from(labelToFieldId.keys()).filter((l) => !coveredLabels.has(l))
+  );
+
+  if (remainingLabels.size === 0) {
+    return suggestions;
+  }
+
   const pastForms = await prisma.form.findMany({
     where: {
       userId,
@@ -76,12 +107,6 @@ export async function getSuggestionsFromHistory(
     take: 20,
   });
 
-  if (pastForms.length === 0) {
-    return [];
-  }
-
-  // For each matching label, track the most recent value and its source form title
-  // Map: normalized label -> { value, formTitle }
   const bestMatch = new Map<string, { value: string; formTitle: string }>();
 
   for (const form of pastForms) {
@@ -92,11 +117,9 @@ export async function getSuggestionsFromHistory(
       if (!pastField.label || !pastField.value) continue;
 
       const normalized = normalizeLabel(pastField.label);
-      if (!labelToFieldId.has(normalized)) continue;
+      if (!remainingLabels.has(normalized)) continue;
       if (isSensitiveLabel(normalized)) continue;
 
-      // Only store if we don't have a value yet (forms are ordered by updatedAt desc,
-      // so the first match per label is the most recent)
       if (!bestMatch.has(normalized)) {
         bestMatch.set(normalized, {
           value: pastField.value,
@@ -106,7 +129,6 @@ export async function getSuggestionsFromHistory(
     }
   }
 
-  const suggestions: FieldSuggestion[] = [];
   for (const [normalizedLabel, match] of bestMatch) {
     const fieldId = labelToFieldId.get(normalizedLabel);
     if (!fieldId) continue;
@@ -116,6 +138,7 @@ export async function getSuggestionsFromHistory(
       value: match.value,
       confidence: 0.6,
       source: match.formTitle,
+      sourceType: "history",
     });
   }
 


### PR DESCRIPTION
## Summary
FormPilot now learns from every completed form. After a form reaches COMPLETED status, field→value pairs are extracted and stored in a per-user `FormMemory` table. Future autofill suggestions query this memory first before scanning form history.

- **`FormMemory` table**: keyed on `userId + label`; classifies fields into `name/email/phone/address/employer/passport/tax_id/custom`
- **Auto-extraction**: triggered non-blocking in `PATCH /api/forms/:id` when status → COMPLETED
- **Suggestion engine updated**: FormMemory queried first (confidence ≥ 0.8); fallback to history scan for unmatched fields; `sourceType: "memory" | "history"` in response
- **"From memory" badge**: emerald badge on suggestion callout when sourceType is memory
- **`/dashboard/memory` settings page**: view all remembered values grouped by field type; delete individual entries or clear all
- **"Memory" nav link** added to DashboardNav

## Privacy
- Sensitive fields (SSN, passport numbers, bank accounts, credit cards, tax IDs) are never stored in memory
- Memory is strictly scoped to `userId` — never shared between users
- No PII sent to Claude if a memory match is found (privacy win + cost reduction)

## Test plan
- [ ] Complete a form — verify `FormMemory` records are created in DB
- [ ] Open a new similar form, click "Get suggestion" on a matching field — see "From memory" badge
- [ ] Visit `/dashboard/memory` — records visible, grouped by type
- [ ] Delete a single record — disappears from list
- [ ] "Clear all memory" — all records removed
- [ ] SSN / bank account fields not stored in memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)