### PR TITLE
feat(#168): paginate dashboard form list with cursor-based load more

### DIFF
--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const PAGE_SIZE = 20;
+
+// GET /api/forms?cursor=<formId>&limit=20
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const cursor = req.nextUrl.searchParams.get("cursor");
+  const limit = Math.min(
+    parseInt(req.nextUrl.searchParams.get("limit") ?? String(PAGE_SIZE), 10),
+    100
+  );
+
+  const forms = await prisma.form.findMany({
+    where: { userId: session.user.id! },
+    orderBy: { createdAt: "desc" },
+    take: limit + 1, // fetch one extra to determine hasMore
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      sourceType: true,
+      category: true,
+      fields: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const hasMore = forms.length > limit;
+  const page = hasMore ? forms.slice(0, limit) : forms;
+
+  const items = page.map((f) => {
+    const fields = f.fields as Array<{ value?: string }>;
+    const totalFields = fields.length;
+    const filledCount = fields.filter((field) => field.value && String(field.value).trim()).length;
+    return {
+      id: f.id,
+      title: f.title,
+      status: f.status,
+      sourceType: f.sourceType,
+      category: f.category ?? null,
+      fieldCount: totalFields,
+      completionPercent: totalFields > 0 ? Math.round((filledCount / totalFields) * 100) : 0,
+      createdAt: f.createdAt,
+      updatedAt: f.updatedAt,
+    };
+  });
+
+  return NextResponse.json({ items, hasMore, nextCursor: hasMore ? page[page.length - 1].id : null });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,11 +9,14 @@ export default async function DashboardPage() {
   const session = await auth();
   if (!session?.user) redirect("/login");
 
+  const PAGE_SIZE = 20;
   const forms = await prisma.form.findMany({
     where: { userId: session.user.id! },
     orderBy: { createdAt: "desc" },
-    take: 20,
+    take: PAGE_SIZE + 1, // fetch one extra to detect hasMore
   });
+  const hasMore = forms.length > PAGE_SIZE;
+  const pagedForms = hasMore ? forms.slice(0, PAGE_SIZE) : forms;
 
   const profile = await prisma.profile.findUnique({
     where: { userId: session.user.id! },
@@ -29,10 +32,10 @@ export default async function DashboardPage() {
     !!profileData?.email;
 
   // Step 3 done: any form has been through analysis/autofill
-  const hasUsedAutofill = forms.some((f) => f.status !== "PENDING");
+  const hasUsedAutofill = pagedForms.some((f) => f.status !== "PENDING");
 
   // Show checklist until all 3 steps done + dismissed
-  const showChecklist = !hasProfileData || forms.length === 0 || !hasUsedAutofill;
+  const showChecklist = !hasProfileData || pagedForms.length === 0 || !hasUsedAutofill;
 
   // Profile completeness for nudge (10 core fields)
   const pd = profileData;
@@ -47,9 +50,9 @@ export default async function DashboardPage() {
   const showProfileNudge = hasProfileData && profileCompleteness < 60 && !showChecklist;
 
   const stats = {
-    total: forms.length,
-    completed: forms.filter((f) => f.status === "COMPLETED").length,
-    inProgress: forms.filter((f) => f.status === "FILLING").length,
+    total: pagedForms.length,
+    completed: pagedForms.filter((f) => f.status === "COMPLETED").length,
+    inProgress: pagedForms.filter((f) => f.status === "FILLING").length,
   };
 
   return (
@@ -57,7 +60,7 @@ export default async function DashboardPage() {
       {showChecklist && (
         <OnboardingChecklist
           hasProfileData={hasProfileData}
-          formsCount={forms.length}
+          formsCount={pagedForms.length}
           hasUsedAutofill={hasUsedAutofill}
         />
       )}
@@ -109,7 +112,7 @@ export default async function DashboardPage() {
         </div>
 
         {/* Content */}
-        {forms.length === 0 ? (
+        {pagedForms.length === 0 ? (
           <div className="bg-white rounded-2xl border border-slate-200 shadow-soft p-12 sm:p-16 text-center">
             <div className="mx-auto w-16 h-16 rounded-2xl bg-blue-50 flex items-center justify-center mb-6">
               <svg className="w-8 h-8 text-blue-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -136,23 +139,26 @@ export default async function DashboardPage() {
             </Link>
           </div>
         ) : (
-          <FormCardList forms={forms.map((f) => {
-            const fields = f.fields as Array<{ value?: string }>;
-            const totalFields = fields.length;
-            const filledCount = fields.filter((field) => field.value && String(field.value).trim()).length;
-            const completionPercent = totalFields > 0 ? Math.round((filledCount / totalFields) * 100) : 0;
-            return {
-              id: f.id,
-              title: f.title,
-              status: f.status,
-              sourceType: f.sourceType,
-              category: f.category ?? null,
-              fieldCount: totalFields,
-              completionPercent,
-              createdAt: f.createdAt,
-              updatedAt: f.updatedAt,
-            };
-          })} />
+          <FormCardList
+            initialHasMore={hasMore}
+            forms={pagedForms.map((f) => {
+              const fields = f.fields as Array<{ value?: string }>;
+              const totalFields = fields.length;
+              const filledCount = fields.filter((field) => field.value && String(field.value).trim()).length;
+              const completionPercent = totalFields > 0 ? Math.round((filledCount / totalFields) * 100) : 0;
+              return {
+                id: f.id,
+                title: f.title,
+                status: f.status,
+                sourceType: f.sourceType,
+                category: f.category ?? null,
+                fieldCount: totalFields,
+                completionPercent,
+                createdAt: f.createdAt,
+                updatedAt: f.updatedAt,
+              };
+            })}
+          />
         )}
       </main>
     </>

--- a/src/components/forms/FormCardList.tsx
+++ b/src/components/forms/FormCardList.tsx
@@ -78,15 +78,38 @@ interface FormCard {
 
 interface Props {
   forms: FormCard[];
+  initialHasMore?: boolean;
 }
 
-export default function FormCardList({ forms: initialForms }: Props) {
+export default function FormCardList({ forms: initialForms, initialHasMore = false }: Props) {
   const router = useRouter();
   const [forms, setForms] = useState(initialForms);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [nextCursor, setNextCursor] = useState<string | null>(
+    initialHasMore && initialForms.length > 0 ? initialForms[initialForms.length - 1].id : null
+  );
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  async function handleLoadMore() {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(`/api/forms?cursor=${nextCursor}&limit=20`);
+      if (!res.ok) throw new Error("Failed to load more");
+      const data = await res.json() as { items: FormCard[]; hasMore: boolean; nextCursor: string | null };
+      setForms((prev) => [...prev, ...data.items]);
+      setHasMore(data.hasMore);
+      setNextCursor(data.nextCursor);
+    } catch {
+      // silently ignore — button stays visible so user can retry
+    } finally {
+      setLoadingMore(false);
+    }
+  }
 
   async function handleDelete(e: React.MouseEvent, id: string, title: string) {
     e.preventDefault();
@@ -230,7 +253,7 @@ export default function FormCardList({ forms: initialForms }: Props) {
           </button>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="space-y-3" aria-live="polite">
           {filteredForms.map((form) => {
             const style = getStatusStyle(form.status);
             const isDeleting = deletingId === form.id;
@@ -314,6 +337,29 @@ export default function FormCardList({ forms: initialForms }: Props) {
               </div>
             );
           })}
+        </div>
+      )}
+
+      {/* Load more — only show when no active filter (filtered view is already a subset of loaded data) */}
+      {hasMore && !hasActiveFilter && (
+        <div className="flex justify-center pt-2">
+          <button
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-slate-600 bg-white border border-slate-200 rounded-xl hover:border-blue-300 hover:text-blue-600 hover:bg-blue-50/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loadingMore ? (
+              <>
+                <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+                  <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
+                </svg>
+                Loading…
+              </>
+            ) : (
+              "Load more"
+            )}
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #168

## Changes

**New:** `src/app/api/forms/route.ts` — `GET /api/forms?cursor=<id>&limit=20`
- Fetches `limit+1` rows to detect `hasMore` without a separate COUNT query
- Returns `{ items, hasMore, nextCursor }`
- Auth-gated, max limit capped at 100

**Updated:** `src/app/dashboard/page.tsx`
- Fetches `PAGE_SIZE+1` forms on initial load to detect `hasMore`
- Passes `initialHasMore` to `FormCardList`

**Updated:** `src/components/forms/FormCardList.tsx`
- New props: `initialHasMore`
- New state: `hasMore`, `nextCursor`, `loadingMore`
- `handleLoadMore` fetches `/api/forms?cursor=X` and appends to form list
- "Load more" button with spinner; hidden when any search/filter is active
- No changes to search, filter, or delete behaviour