### PR TITLE
feat(#177): send "form analyzed" email when upload analysis completes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ NEXT_PUBLIC_PRO_PRICE="$9/mo"
 
 # Feature flags
 SHOW_TESTIMONIALS="false"
+# Set to "true" in local dev to allow email sends (requires RESEND_API_KEY)
+SEND_EMAILS="false"
 
 # Resend transactional email (get API key from resend.com)
 RESEND_API_KEY=""

--- a/src/app/api/forms/upload/route.ts
+++ b/src/app/api/forms/upload/route.ts
@@ -9,6 +9,8 @@ import { checkRateLimit, checkIpRateLimit } from "@/lib/rate-limit";
 import { handleApiError } from "@/lib/api-error";
 import { log } from "@/lib/logger";
 import type { FormAnalysis } from "@/lib/ai/analyze-form";
+import { sendEmail } from "@/lib/email";
+import FormAnalyzedEmail from "@/emails/FormAnalyzedEmail";
 
 export const maxDuration = 60;
 
@@ -170,6 +172,16 @@ export async function POST(req: NextRequest) {
 
     // Non-blocking usage increment — don't fail the upload if this errors
     incrementFormUsage(session.user.id).catch(() => {});
+
+    // Non-blocking "form is ready" email — skip if no email on session
+    if (session.user.email) {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://getformpilot.com";
+      sendEmail(
+        session.user.email,
+        `Your form "${form.title}" is ready to fill`,
+        FormAnalyzedEmail({ formTitle: form.title, formId: form.id, fieldCount: analysis.fields.length, appUrl })
+      ).catch(() => {});
+    }
 
     return NextResponse.json({ formId: form.id });
   } catch (err) {

--- a/src/emails/FormAnalyzedEmail.tsx
+++ b/src/emails/FormAnalyzedEmail.tsx
@@ -1,0 +1,80 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Text,
+} from "@react-email/components";
+import * as React from "react";
+
+interface Props {
+  formTitle: string;
+  formId: string;
+  fieldCount: number;
+  appUrl: string;
+}
+
+export default function FormAnalyzedEmail({ formTitle, formId, fieldCount, appUrl }: Props) {
+  const formUrl = `${appUrl}/dashboard/forms/${formId}`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{`Your form "${formTitle}" is ready to fill — ${String(fieldCount)} fields found`}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Heading style={logo}>
+            Form<span style={logoBlue}>Pilot</span>
+          </Heading>
+
+          <Heading style={h1}>Your form is ready to fill</Heading>
+
+          <Text style={text}>
+            <strong>{formTitle}</strong> has been analyzed.
+            We found <strong>{fieldCount} field{fieldCount !== 1 ? "s" : ""}</strong> — each
+            one explained in plain language with autofill suggestions from your profile.
+          </Text>
+
+          <Button style={button} href={formUrl}>
+            Start filling →
+          </Button>
+
+          <Hr style={hr} />
+
+          <Text style={footer}>
+            FormPilot · {appUrl} ·{" "}
+            <a href={`${appUrl}/privacy`} style={link}>
+              Privacy Policy
+            </a>
+            <br />
+            You&apos;re receiving this because you uploaded a form to FormPilot.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+const main = { backgroundColor: "#f8fafc", fontFamily: "'Inter', -apple-system, sans-serif" };
+const container = { margin: "0 auto", padding: "40px 20px", maxWidth: "560px" };
+const logo = { fontSize: "24px", fontWeight: "800", color: "#0f172a", marginBottom: "32px" };
+const logoBlue = { color: "#2563eb" };
+const h1 = { fontSize: "24px", fontWeight: "700", color: "#0f172a", margin: "0 0 16px" };
+const text = { fontSize: "16px", lineHeight: "24px", color: "#475569", margin: "0 0 24px" };
+const button = {
+  backgroundColor: "#2563eb",
+  borderRadius: "8px",
+  color: "#fff",
+  fontSize: "15px",
+  fontWeight: "600",
+  padding: "12px 24px",
+  textDecoration: "none",
+  display: "inline-block",
+};
+const hr = { borderColor: "#e2e8f0", margin: "32px 0 24px" };
+const footer = { fontSize: "13px", color: "#94a3b8", lineHeight: "20px" };
+const link = { color: "#94a3b8" };

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -22,6 +22,11 @@ export async function sendEmail(
     // Skip silently in dev/test environments without a key configured
     return;
   }
+  // In local development, require explicit opt-in via SEND_EMAILS=true to avoid
+  // accidentally sending emails during development/testing
+  if (process.env.NODE_ENV !== "production" && process.env.SEND_EMAILS !== "true") {
+    return;
+  }
   const html = await render(template);
   await getResend().emails.send({ from: FROM, to, subject, html });
 }


### PR DESCRIPTION
Closes #177

## Changes
- `src/emails/FormAnalyzedEmail.tsx` — new React Email template (matches existing design system)
- `src/lib/email.ts` — add `SEND_EMAILS=true` dev guard to prevent accidental sends in local development
- `src/app/api/forms/upload/route.ts` — fire-and-forget email after `form.create()`, guarded by `session.user.email` presence
- `.env.example` — document `SEND_EMAILS` flag

## Design decisions
- Fire-and-forget (`.catch(() => {})`) — email send never blocks or fails the upload response
- Single send point (upload route only) — forms are only created with `ANALYZED` status here, no duplicate send risk
- `SEND_EMAILS` env var as local dev gate — production always sends when `RESEND_API_KEY` is set