### PR TITLE
feat(#180): confetti burst on successful form export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "canvas": "^3.2.2",
+        "canvas-confetti": "^1.9.4",
         "groq-sdk": "^1.1.2",
         "mammoth": "^1.12.0",
         "next": "^16.2.1",
@@ -36,6 +37,7 @@
         "zod": "^3.24.0"
       },
       "devDependencies": {
+        "@types/canvas-confetti": "^1.9.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/pdf-parse": "^1.1.4",
@@ -5097,6 +5099,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -7092,6 +7101,16 @@
       },
       "engines": {
         "node": "^18.12.0 || >= 20.9.0"
+      }
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
       }
     },
     "node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "canvas": "^3.2.2",
+    "canvas-confetti": "^1.9.4",
     "groq-sdk": "^1.1.2",
     "mammoth": "^1.12.0",
     "next": "^16.2.1",
@@ -48,6 +49,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@types/canvas-confetti": "^1.9.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/pdf-parse": "^1.1.4",

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -371,6 +371,13 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
         "form_filled.json";
       a.click();
       URL.revokeObjectURL(blobUrl);
+
+      // Celebrate successful export — skip if user prefers reduced motion
+      if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+        import("canvas-confetti").then(({ default: confetti }) => {
+          confetti({ particleCount: 120, spread: 70, origin: { y: 0.6 }, colors: ["#2563eb", "#7c3aed", "#10b981", "#f59e0b"] });
+        });
+      }
     } finally {
       setExporting(false);
     }


### PR DESCRIPTION
## Summary
- Adds `canvas-confetti` (3 kB gzipped) as a dependency
- Fires a confetti burst in `doExport()` immediately after the file download is triggered, only on confirmed success (not on click, not on failure)
- Dynamically imported (`import('canvas-confetti')`) — zero impact on initial bundle
- Skipped entirely when `prefers-reduced-motion: reduce` is set
- Uses brand colours (blue, violet, green, amber)

## Test plan
- [ ] Export a form → confetti burst fires
- [ ] Export fails → no confetti
- [ ] Enable `prefers-reduced-motion: reduce` in browser → no confetti on export
- [ ] Check bundle: confetti chunk only loaded after successful export

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)