### PR TITLE
fix(#192): auto-reset free tier monthly form quota on new calendar month

### DIFF
--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -27,6 +27,7 @@ export async function canUploadForm(userId: string): Promise<
 > {
   if (await isProUser(userId)) return { allowed: true };
 
+  // getOrCreateUsage lazily resets the counter when a new calendar month starts
   const usage = await getOrCreateUsage(userId);
   if (usage.formsThisMonth < FREE_FORM_LIMIT) return { allowed: true };
   return { allowed: false, formsUsed: usage.formsThisMonth, limit: FREE_FORM_LIMIT };
@@ -41,13 +42,28 @@ export async function incrementFormUsage(userId: string): Promise<void> {
   });
 }
 
-/** Returns current usage count, creating the record if it doesn't exist */
+/** Returns current usage count, creating the record if it doesn't exist.
+ *  Lazily resets the counter when a new calendar month has started — necessary
+ *  because free users never pay, so the Stripe invoice webhook never fires for them. */
 export async function getOrCreateUsage(userId: string) {
-  return prisma.usageCount.upsert({
+  const record = await prisma.usageCount.upsert({
     where: { userId },
     create: { userId, formsThisMonth: 0, periodStart: new Date() },
     update: {},
   });
+
+  const now = new Date();
+  const periodStart = new Date(record.periodStart);
+  const isNewMonth =
+    now.getFullYear() !== periodStart.getFullYear() ||
+    now.getMonth() !== periodStart.getMonth();
+
+  if (isNewMonth) {
+    await resetMonthlyUsage(userId);
+    return { ...record, formsThisMonth: 0, periodStart: now };
+  }
+
+  return record;
 }
 
 /** Resets monthly usage — called from Stripe webhook on invoice.paid */


### PR DESCRIPTION
## Root cause

`getOrCreateUsage` used `update: {}` — meaning the `formsThisMonth` counter was **never reset** for free users. `resetMonthlyUsage` is only called from the Stripe `invoice.paid` webhook, which free users never trigger. A free user who hit their 5-form limit would be permanently blocked on the upload page (`isAtLimit = true` → upgrade modal instead of upload).

## Fix

Added lazy calendar-month reset inside `getOrCreateUsage`:
- On every call, compare `record.periodStart` to the current month
- If a new month has started, call `resetMonthlyUsage` and return `formsThisMonth: 0`
- All callers (`canUploadForm`, `/api/billing`, dashboard stats) automatically get the correct count

`canUploadForm` is simplified — no duplicate logic needed since `getOrCreateUsage` now handles the reset.

## Test plan
- [ ] Free user who used 5 forms in month A can upload again in month B
- [ ] Free user mid-month (same month as `periodStart`) is correctly gated at 5 forms
- [ ] Pro user is unaffected (early return before `getOrCreateUsage` is called)
- [ ] `/api/billing` returns `formsUsed: 0` for a free user in a new month

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)