### PR TITLE
feat(#188): re-fill new form from a previous submission

### DIFF
--- a/src/app/api/forms/[id]/re-fill/route.ts
+++ b/src/app/api/forms/[id]/re-fill/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
+import { getClient } from "@/lib/ai/analyze-form";
+import { log } from "@/lib/logger";
+import { z } from "zod";
+import type { FormField } from "@/lib/ai/analyze-form";
+
+export const maxDuration = 60;
+
+const bodySchema = z.object({
+  sourceFormId: z.string().min(1),
+});
+
+const mappingSchema = z.array(
+  z.object({
+    newFieldId: z.string(),
+    value: z.string().nullable(),
+  })
+);
+
+const DATE_VERIFY_RE = /date|expir|year|current|today|period/i;
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "sourceFormId is required" }, { status: 400 });
+  }
+
+  const { sourceFormId } = parsed.data;
+
+  try {
+    // Load both forms, verify ownership
+    const [targetForm, sourceForm] = await Promise.all([
+      prisma.form.findUnique({ where: { id } }),
+      prisma.form.findUnique({ where: { id: sourceFormId } }),
+    ]);
+
+    if (!targetForm || targetForm.userId !== session.user.id) {
+      return NextResponse.json({ error: "Target form not found" }, { status: 404 });
+    }
+    if (!sourceForm || sourceForm.userId !== session.user.id) {
+      return NextResponse.json({ error: "Source form not found" }, { status: 404 });
+    }
+
+    const targetFields = targetForm.fields as unknown as FormField[];
+    const sourceFields = sourceForm.fields as unknown as FormField[];
+
+    // Build the old-form values: label → value (only filled fields)
+    const sourceValues = sourceFields
+      .filter((f) => f.value && String(f.value).trim())
+      .map((f) => ({ label: f.label, value: f.value! }));
+
+    if (sourceValues.length === 0) {
+      return NextResponse.json({ error: "Source form has no filled values" }, { status: 400 });
+    }
+
+    // Build the new field list for Claude
+    const newFieldList = targetFields.map((f) => ({
+      id: f.id,
+      label: f.label,
+      type: f.type,
+    }));
+
+    const prompt = `You are a form field mapping assistant. A user wants to pre-fill a new form using answers from a previous form they completed.
+
+Old form filled values (label → value):
+${sourceValues.map((v) => `"${v.label}": "${v.value}"`).join("\n")}
+
+New form fields to fill (id, label, type):
+${newFieldList.map((f) => `id="${f.id}" label="${f.label}" type="${f.type}"`).join("\n")}
+
+For each new field, find the best matching old value. A match is valid when the field labels describe the same information (e.g. "First Name" matches "Given Name"). Use your judgment for minor wording differences.
+
+Return ONLY a valid JSON array (no markdown, no extra text) in this exact format:
+[
+  { "newFieldId": "<id>", "value": "<matched value or null if no match>" }
+]
+
+Include ALL new field IDs in the output. Set value to null when there is no reasonable match.`;
+
+    const client = getClient();
+    const completion = await client.chat.completions.create({
+      model: "llama-3.3-70b-versatile",
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0.1,
+      max_tokens: 2048,
+    });
+
+    const raw = completion.choices[0]?.message?.content ?? "[]";
+
+    // Strip markdown fences if present
+    const cleaned = raw
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```$/i, "")
+      .trim();
+
+    let mappings: Array<{ newFieldId: string; value: string | null }>;
+    try {
+      const parsed2 = mappingSchema.safeParse(JSON.parse(cleaned));
+      if (!parsed2.success) {
+        throw new Error("Invalid mapping response shape");
+      }
+      mappings = parsed2.data;
+    } catch {
+      log.warn("re-fill: failed to parse Claude mapping response", {
+        route: "POST /api/forms/[id]/re-fill",
+        raw: raw.slice(0, 500),
+      });
+      return NextResponse.json({ error: "AI mapping failed — try again" }, { status: 502 });
+    }
+
+    // Apply mappings to target fields
+    const mappingMap = new Map(mappings.map((m) => [m.newFieldId, m.value]));
+    const updatedFields = targetFields.map((f): FormField => {
+      const mappedValue = mappingMap.get(f.id);
+      if (mappedValue) {
+        return {
+          ...f,
+          value: mappedValue,
+          // Use 0.85 confidence for prior-fill matches — clearly sourced, not profile-guessed
+          confidence: 0.85,
+          matchedFrom: "prior_fill",
+          fieldState: "pending",
+        };
+      }
+      return f;
+    });
+
+    await prisma.form.update({
+      where: { id },
+      data: {
+        fields: updatedFields as object[],
+        filledData: Object.fromEntries(
+          updatedFields.filter((f) => f.value).map((f) => [f.id, f.value!])
+        ),
+        status: "FILLING",
+      },
+    });
+
+    const matchedCount = updatedFields.filter((f) => f.matchedFrom === "prior_fill").length;
+
+    log.info("Form re-filled from prior submission", {
+      route: "POST /api/forms/[id]/re-fill",
+      targetFormId: id,
+      sourceFormId,
+      matchedCount,
+      totalFields: targetFields.length,
+    });
+
+    return NextResponse.json({ fields: updatedFields, matchedCount });
+  } catch (err) {
+    return handleApiError(err, "POST /api/forms/[id]/re-fill");
+  }
+}

--- a/src/app/dashboard/upload/page.tsx
+++ b/src/app/dashboard/upload/page.tsx
@@ -4,6 +4,15 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
+interface PriorForm {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  completionPercent: number;
+  fieldCount: number;
+}
+
 interface BillingInfo {
   plan: "free" | "pro";
   formsUsed: number;
@@ -63,6 +72,15 @@ export default function UploadPage() {
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [upgradeLoading, setUpgradeLoading] = useState(false);
   const [retryAfter, setRetryAfter] = useState<number | null>(null);
+  // Prior fill state
+  const [priorFormId, setPriorFormId] = useState<string | null>(null);
+  const [priorFormTitle, setPriorFormTitle] = useState<string | null>(null);
+  const [showPriorModal, setShowPriorModal] = useState(false);
+  const [priorForms, setPriorForms] = useState<PriorForm[] | null>(null);
+  const [loadingPriorForms, setLoadingPriorForms] = useState(false);
+  const [priorFormsCursor, setPriorFormsCursor] = useState<string | null>(null);
+  const [hasMorePriorForms, setHasMorePriorForms] = useState(false);
+  const [reFilling, setReFilling] = useState(false);
 
   // Fetch billing info once on mount for pre-flight limit check
   useEffect(() => {
@@ -72,15 +90,43 @@ export default function UploadPage() {
       .catch(() => {});
   }, []);
 
-  // Close modal on Escape key
+  // Close modals on Escape key
   useEffect(() => {
-    if (!showUpgradeModal) return;
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setShowUpgradeModal(false);
+      if (e.key === "Escape") {
+        setShowUpgradeModal(false);
+        setShowPriorModal(false);
+      }
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [showUpgradeModal]);
+  }, []);
+
+  async function loadPriorForms(cursor?: string) {
+    setLoadingPriorForms(true);
+    try {
+      const url = cursor ? `/api/forms?limit=10&cursor=${cursor}` : "/api/forms?limit=10";
+      const res = await fetch(url);
+      if (!res.ok) return;
+      const data = await res.json() as { items: PriorForm[]; hasMore: boolean; nextCursor: string | null };
+      // Only show forms that have some filled data
+      const filled = data.items.filter((f) => f.completionPercent > 0);
+      setPriorForms((prev) => cursor ? [...(prev ?? []), ...filled] : filled);
+      setHasMorePriorForms(data.hasMore);
+      setPriorFormsCursor(data.nextCursor);
+    } catch {
+      // silently ignore
+    } finally {
+      setLoadingPriorForms(false);
+    }
+  }
+
+  function openPriorModal() {
+    setShowPriorModal(true);
+    if (!priorForms) {
+      loadPriorForms();
+    }
+  }
 
   async function handleUpgrade() {
     setUpgradeLoading(true);
@@ -267,6 +313,22 @@ export default function UploadPage() {
       setUploadProgress(100);
       const { formId } = await res.json();
 
+      // If user selected a prior form, map old values to new form before navigating
+      if (priorFormId) {
+        setReFilling(true);
+        try {
+          await fetch(`/api/forms/${formId}/re-fill`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ sourceFormId: priorFormId }),
+          });
+        } catch {
+          // Non-fatal — proceed even if re-fill fails
+        } finally {
+          setReFilling(false);
+        }
+      }
+
       // Brief delay so user sees 100%
       await new Promise((resolve) => setTimeout(resolve, 300));
       router.push(`/dashboard/forms/${formId}`);
@@ -296,6 +358,106 @@ export default function UploadPage() {
 
   return (
     <div>
+      {/* Prior form picker modal */}
+      {showPriorModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
+          onClick={() => setShowPriorModal(false)}
+        >
+          <div
+            className="relative bg-white rounded-2xl shadow-card w-full max-w-lg p-6 animate-slide-down max-h-[80vh] flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4 shrink-0">
+              <h2 className="text-lg font-bold text-slate-900">Choose a previous form</h2>
+              <button
+                onClick={() => setShowPriorModal(false)}
+                className="text-slate-400 hover:text-slate-600 transition-colors"
+                aria-label="Close"
+              >
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+
+            <p className="text-sm text-slate-500 mb-4 shrink-0">
+              We&apos;ll use your prior answers to pre-fill fields in the new form. You can review and update anything that&apos;s changed.
+            </p>
+
+            <div className="overflow-y-auto flex-1 space-y-2 min-h-0">
+              {loadingPriorForms && !priorForms && (
+                <div className="flex items-center justify-center py-8 text-slate-400 text-sm">
+                  <svg className="w-4 h-4 animate-spin mr-2" viewBox="0 0 24 24" fill="none">
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+                    <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
+                  </svg>
+                  Loading your forms...
+                </div>
+              )}
+              {priorForms && priorForms.length === 0 && (
+                <div className="py-8 text-center text-sm text-slate-400">
+                  No previously filled forms found. Fill out a form first, then use this feature on your next one.
+                </div>
+              )}
+              {priorForms?.map((f) => (
+                <button
+                  key={f.id}
+                  onClick={() => {
+                    setPriorFormId(f.id);
+                    setPriorFormTitle(f.title);
+                    setShowPriorModal(false);
+                  }}
+                  className={`w-full text-left px-4 py-3 rounded-xl border transition-all ${
+                    priorFormId === f.id
+                      ? "border-blue-400 bg-blue-50"
+                      : "border-slate-200 hover:border-blue-300 hover:bg-slate-50"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-slate-900 truncate">{f.title}</p>
+                      <p className="text-xs text-slate-400 mt-0.5">
+                        {f.fieldCount} fields &middot; {f.completionPercent}% filled &middot;{" "}
+                        {new Date(f.updatedAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                      </p>
+                    </div>
+                    {priorFormId === f.id && (
+                      <svg className="w-4 h-4 text-blue-600 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                      </svg>
+                    )}
+                  </div>
+                </button>
+              ))}
+              {hasMorePriorForms && (
+                <button
+                  onClick={() => loadPriorForms(priorFormsCursor ?? undefined)}
+                  disabled={loadingPriorForms}
+                  className="w-full py-2.5 text-sm text-blue-600 hover:text-blue-800 disabled:opacity-50 transition-colors"
+                >
+                  {loadingPriorForms ? "Loading..." : "Load more"}
+                </button>
+              )}
+            </div>
+
+            {priorFormId && (
+              <div className="mt-4 pt-4 border-t border-slate-100 shrink-0 flex items-center justify-between gap-3">
+                <p className="text-xs text-slate-500 truncate">
+                  Selected: <span className="font-medium text-slate-700">{priorFormTitle}</span>
+                </p>
+                <button
+                  onClick={() => { setPriorFormId(null); setPriorFormTitle(null); setShowPriorModal(false); }}
+                  className="text-xs text-slate-400 hover:text-red-600 transition-colors shrink-0"
+                >
+                  Clear
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Upgrade modal */}
       {showUpgradeModal && (
         <div
@@ -564,6 +726,52 @@ export default function UploadPage() {
               </button>
             )}
 
+            {/* Use answers from a previous fill */}
+            {priorFormId ? (
+              <div className="flex items-center gap-2 px-3 py-2.5 rounded-xl border border-blue-200 bg-blue-50 text-sm">
+                <svg className="w-4 h-4 text-blue-600 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <polyline points="9 15 12 12 15 15" />
+                  <line x1="12" y1="12" x2="12" y2="18" />
+                </svg>
+                <span className="flex-1 min-w-0 text-blue-800">
+                  Pre-filling from: <span className="font-medium truncate">{priorFormTitle}</span>
+                </span>
+                <button
+                  type="button"
+                  onClick={openPriorModal}
+                  className="text-blue-600 hover:text-blue-800 font-medium shrink-0 transition-colors"
+                >
+                  Change
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setPriorFormId(null); setPriorFormTitle(null); }}
+                  className="text-blue-400 hover:text-red-600 shrink-0 transition-colors"
+                  aria-label="Remove prior form selection"
+                >
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={openPriorModal}
+                className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl border border-slate-200 text-slate-600 text-sm font-medium hover:border-blue-300 hover:text-blue-600 hover:bg-blue-50/50 transition-all"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="12" y1="18" x2="12" y2="12" />
+                  <line x1="9" y1="15" x2="15" y2="15" />
+                </svg>
+                Use answers from a previous fill
+              </button>
+            )}
+
             {/* Clipboard paste hint */}
             <p className="text-xs text-slate-400 text-center -mt-2">
               You can also paste a screenshot from your clipboard{" "}
@@ -601,13 +809,15 @@ export default function UploadPage() {
               <div className="space-y-3 animate-fade-in">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-slate-600 font-medium transition-all duration-500">
-                    {[
-                      "Uploading file...",
-                      "Parsing document...",
-                      "Identifying fields...",
-                      "Generating explanations...",
-                      "Almost ready...",
-                    ][loadingStep]}
+                    {reFilling
+                      ? "Applying prior answers..."
+                      : [
+                          "Uploading file...",
+                          "Parsing document...",
+                          "Identifying fields...",
+                          "Generating explanations...",
+                          "Almost ready...",
+                        ][loadingStep]}
                   </span>
                   <span className="text-slate-400 tabular-nums">
                     {Math.round(uploadProgress)}%

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -882,8 +882,21 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
         </div>
       )}
 
+      {/* Prior fill banner — shown when form was pre-filled from a previous submission */}
+      {fields.some((f) => f.matchedFrom === "prior_fill") && (
+        <div className="flex items-center gap-2.5 px-4 py-2.5 bg-violet-50 border border-violet-100 rounded-xl text-sm text-violet-700">
+          <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            <polyline points="9 15 12 12 15 15" />
+            <line x1="12" y1="12" x2="12" y2="18" />
+          </svg>
+          Pre-filled from a previous form — {fields.filter((f) => f.matchedFrom === "prior_fill").length} fields matched. Review and update any that may have changed.
+        </div>
+      )}
+
       {/* Resume session banner — shown when returning to an in-progress form */}
-      {form.status === "FILLING" && filledCount > 0 && (
+      {form.status === "FILLING" && filledCount > 0 && !fields.some((f) => f.matchedFrom === "prior_fill") && (
         <div className="flex items-center gap-2.5 px-4 py-2.5 bg-blue-50 border border-blue-100 rounded-xl text-sm text-blue-700">
           <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <circle cx="12" cy="12" r="10" />
@@ -972,6 +985,24 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                       {state === "rejected" && (
                         <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-slate-100 text-slate-500">
                           Skipped
+                        </span>
+                      )}
+                      {field.matchedFrom === "prior_fill" && state !== "accepted" && state !== "rejected" && (
+                        <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-violet-100 text-violet-700">
+                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                            <polyline points="14 2 14 8 20 8" />
+                            <polyline points="9 15 12 12 15 15" />
+                          </svg>
+                          Prior fill
+                        </span>
+                      )}
+                      {field.matchedFrom === "prior_fill" && /date|expir|year|current|today|period/i.test(field.label) && state !== "accepted" && state !== "rejected" && (
+                        <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700">
+                          <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                            <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                          </svg>
+                          Verify this
                         </span>
                       )}
                     </div>

--- a/src/lib/ai/analyze-form.ts
+++ b/src/lib/ai/analyze-form.ts
@@ -67,6 +67,8 @@ export interface FormField {
   fieldState?: FieldState;
   /** Optional bounding box from PDF analysis (0–1 fractions of page size). */
   coordinates?: FieldCoordinates;
+  /** Set to "prior_fill" when value was mapped from a previous form submission. */
+  matchedFrom?: "prior_fill";
 }
 
 export interface FormAnalysis {


### PR DESCRIPTION
## Summary

- New `POST /api/forms/[id]/re-fill` endpoint — uses Groq to map field values from a completed source form to a new form's field labels, returns matched fields with `matchedFrom: "prior_fill"` and 0.85 confidence
- Upload page: "Use answers from a previous fill" secondary CTA opens a modal listing the user's previously filled forms (paginated 10); selected prior form is applied automatically after the new form is analyzed
- FormViewer: violet "Prior fill" badge on matched fields; yellow "Verify this" badge on date/expiry/year fields; violet banner at top showing match count
- `FormField` type extended with `matchedFrom?: "prior_fill"`
- Available to Free and Pro users — no extra quota cost (reuses existing form data, no new analysis)

## Test plan

- [ ] Upload page shows "Use answers from a previous fill" button below the camera button
- [ ] Clicking it opens modal listing previously filled forms
- [ ] Selecting a form shows the selection with title in the upload area
- [ ] After uploading a new form, the re-fill runs and matched fields appear in FormViewer with violet "Prior fill" badge
- [ ] Fields with date/expiry/year labels get the yellow "Verify this" badge
- [ ] The violet banner at the top shows correct match count
- [ ] If no prior forms exist, modal shows empty state message
- [ ] Selecting then clearing a prior form works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)