### PR TITLE
feat(#189): learn from corrections — save edited autofill values as preferences

### DIFF
--- a/src/app/api/corrections/[id]/route.ts
+++ b/src/app/api/corrections/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const record = await prisma.formMemory.findUnique({ where: { id } });
+  if (!record || record.userId !== session.user.id || record.fieldType !== "correction") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  await prisma.formMemory.delete({ where: { id } });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/corrections/route.ts
+++ b/src/app/api/corrections/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { z } from "zod";
+import { normalizeLabel } from "@/lib/ai/suggestion-engine";
+
+const bodySchema = z.object({
+  fieldLabel: z.string().min(1).max(200),
+  value: z.string().min(1).max(2000),
+});
+
+// GET /api/corrections — list all saved corrections for the current user
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const corrections = await prisma.formMemory.findMany({
+    where: { userId: session.user.id, fieldType: "correction" },
+    orderBy: { lastUsed: "desc" },
+    select: { id: true, label: true, value: true, lastUsed: true },
+  });
+
+  return NextResponse.json({ corrections });
+}
+
+// POST /api/corrections — save or update a correction
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "fieldLabel and value are required" }, { status: 400 });
+  }
+
+  const { fieldLabel, value } = parsed.data;
+  const normalizedLabel = normalizeLabel(fieldLabel);
+
+  if (!normalizedLabel) {
+    return NextResponse.json({ error: "Invalid field label" }, { status: 400 });
+  }
+
+  // Upsert into FormMemory — corrections override auto-extracted memory for the same label
+  const correction = await prisma.formMemory.upsert({
+    where: { userId_label: { userId: session.user.id, label: normalizedLabel } },
+    create: {
+      userId: session.user.id,
+      fieldType: "correction",
+      label: normalizedLabel,
+      value,
+      confidence: 1.0,
+      sourceFormId: "manual",
+      sourceTitle: "Manual correction",
+      lastUsed: new Date(),
+    },
+    update: {
+      value,
+      fieldType: "correction",
+      confidence: 1.0,
+      lastUsed: new Date(),
+    },
+    select: { id: true, label: true, value: true },
+  });
+
+  return NextResponse.json({ correction });
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -2,15 +2,21 @@ import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import ProfileForm from "@/components/forms/ProfileForm";
+import SavedCorrections from "@/components/forms/SavedCorrections";
 import Link from "next/link";
 
 export default async function ProfilePage() {
   const session = await auth();
   if (!session?.user) redirect("/login");
 
-  const profile = await prisma.profile.findUnique({
-    where: { userId: session.user.id! },
-  });
+  const [profile, corrections] = await Promise.all([
+    prisma.profile.findUnique({ where: { userId: session.user.id! } }),
+    prisma.formMemory.findMany({
+      where: { userId: session.user.id!, fieldType: "correction" },
+      orderBy: { lastUsed: "desc" },
+      select: { id: true, label: true, value: true, lastUsed: true },
+    }),
+  ]);
 
   return (
     <div>
@@ -52,6 +58,12 @@ export default async function ProfilePage() {
             initialPreferredLanguage={profile?.preferredLanguage ?? null}
           />
         </div>
+
+        {corrections.length > 0 && (
+          <div className="bg-white rounded-2xl border border-slate-200 shadow-soft p-6 sm:p-8 mt-6">
+            <SavedCorrections initialCorrections={corrections} />
+          </div>
+        )}
       </main>
     </div>
   );

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -96,6 +96,16 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   // per-field AI suggestions
   const [suggestingFields, setSuggestingFields] = useState<Set<string>>(new Set());
   const [fieldSuggestions, setFieldSuggestions] = useState<Record<string, { value: string; source: string; sourceType?: "memory" | "history" } | { error: true } | null>>({});
+  // correction toasts — fieldId → "pending" | "saving" | "saved" | "dismissed"
+  const [correctionToasts, setCorrectionToasts] = useState<Record<string, "pending" | "saving" | "saved" | "dismissed">>({});
+  // original autofilled values keyed by fieldId — set once on mount, never updated
+  const originalAutofillValues = useRef<Record<string, string>>(
+    Object.fromEntries(
+      initialFields
+        .filter((f) => f.value && f.confidence !== undefined && f.confidence > 0)
+        .map((f) => [f.id, f.value!])
+    )
+  );
   // keyboard navigation for unanswered fields
   const [currentUnansweredIndex, setCurrentUnansweredIndex] = useState(0);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -205,6 +215,51 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
 
   function dismissSuggestion(fieldId: string) {
     setFieldSuggestions((prev) => { const next = { ...prev }; delete next[fieldId]; return next; });
+  }
+
+  // -- correction handling --
+
+  function handleFieldBlurForCorrection(fieldId: string, fieldLabel: string) {
+    const currentValue = values[fieldId];
+    const originalValue = originalAutofillValues.current[fieldId];
+    // Only prompt if: field was autofilled, value changed, toast not already shown/dismissed
+    if (
+      originalValue !== undefined &&
+      currentValue &&
+      currentValue !== originalValue &&
+      correctionToasts[fieldId] === undefined
+    ) {
+      setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "pending" }));
+      // Store label for the save action
+      originalAutofillValues.current[`${fieldId}__label`] = fieldLabel;
+    }
+  }
+
+  function dismissCorrectionToast(fieldId: string) {
+    setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "dismissed" }));
+  }
+
+  async function saveCorrection(fieldId: string) {
+    const fieldLabel = originalAutofillValues.current[`${fieldId}__label`] ?? "";
+    const value = values[fieldId];
+    if (!fieldLabel || !value) {
+      dismissCorrectionToast(fieldId);
+      return;
+    }
+    setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "saving" }));
+    try {
+      await fetch("/api/corrections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fieldLabel, value }),
+      });
+      setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "saved" }));
+      setTimeout(() => {
+        setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "dismissed" }));
+      }, 2000);
+    } catch {
+      dismissCorrectionToast(fieldId);
+    }
   }
 
   function handleAcceptAllHigh() {
@@ -1060,6 +1115,7 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                           onBlur={() => {
                             setActiveField(null);
                             onFieldFocus?.(null);
+                            handleFieldBlurForCorrection(field.id, field.label);
                           }}
                           disabled={state === "accepted"}
                           aria-disabled={state === "accepted"}
@@ -1096,6 +1152,40 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                         {warn.message}
                       </p>
                     ))}
+                    {/* Correction toast — shown when user edits an AI-autofilled field */}
+                    {correctionToasts[field.id] === "pending" && (
+                      <div className="mt-2 flex items-center gap-2 px-3 py-2 bg-violet-50 border border-violet-200 rounded-lg text-xs animate-slide-down">
+                        <svg className="w-3.5 h-3.5 text-violet-600 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19H4v-3L16.5 3.5z"/></svg>
+                        <span className="text-violet-800 flex-1">Save as preference?</span>
+                        <button
+                          type="button"
+                          onClick={() => saveCorrection(field.id)}
+                          className="text-violet-700 font-semibold hover:text-violet-900 transition-colors"
+                        >
+                          Save
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => dismissCorrectionToast(field.id)}
+                          className="text-violet-400 hover:text-violet-600 transition-colors"
+                          aria-label="Dismiss"
+                        >
+                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                        </button>
+                      </div>
+                    )}
+                    {correctionToasts[field.id] === "saving" && (
+                      <div className="mt-2 flex items-center gap-2 px-3 py-2 bg-violet-50 border border-violet-200 rounded-lg text-xs">
+                        <svg className="w-3.5 h-3.5 animate-spin text-violet-600" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25"/><path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75"/></svg>
+                        <span className="text-violet-700">Saving...</span>
+                      </div>
+                    )}
+                    {correctionToasts[field.id] === "saved" && (
+                      <div className="mt-2 flex items-center gap-2 px-3 py-2 bg-emerald-50 border border-emerald-200 rounded-lg text-xs animate-slide-down">
+                        <svg className="w-3.5 h-3.5 text-emerald-600" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd"/></svg>
+                        <span className="text-emerald-700 font-medium">Saved as preference</span>
+                      </div>
+                    )}
                   </div>
 
                   {/* Right column: confidence + actions */}

--- a/src/components/forms/SavedCorrections.tsx
+++ b/src/components/forms/SavedCorrections.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+interface Correction {
+  id: string;
+  label: string;
+  value: string;
+  lastUsed: Date | string;
+}
+
+interface Props {
+  initialCorrections: Correction[];
+}
+
+export default function SavedCorrections({ initialCorrections }: Props) {
+  const [corrections, setCorrections] = useState<Correction[]>(initialCorrections);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  async function handleDelete(id: string) {
+    setDeletingId(id);
+    try {
+      const res = await fetch(`/api/corrections/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setCorrections((prev) => prev.filter((c) => c.id !== id));
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  if (corrections.length === 0) return null;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-bold text-slate-900">Saved Corrections</h2>
+        <p className="text-sm text-slate-500 mt-1">
+          Corrections you&apos;ve saved from editing AI-autofilled fields. These are used as preferences when autofilling future forms.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {corrections.map((c) => (
+          <div
+            key={c.id}
+            className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-slate-200 bg-slate-50/50"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">{c.label}</p>
+              <p className="text-sm text-slate-900 truncate mt-0.5">{c.value}</p>
+            </div>
+            <div className="flex items-center gap-3 shrink-0">
+              <span className="text-xs text-slate-400 hidden sm:block">
+                {new Date(c.lastUsed).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+              </span>
+              <button
+                onClick={() => handleDelete(c.id)}
+                disabled={deletingId === c.id}
+                className="text-slate-400 hover:text-red-600 transition-colors disabled:opacity-40"
+                aria-label={`Delete correction for ${c.label}`}
+              >
+                {deletingId === c.id ? (
+                  <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+                    <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
+                  </svg>
+                ) : (
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="3 6 5 6 21 6" />
+                    <path d="M19 6l-1 14H6L5 6" />
+                    <path d="M10 11v6M14 11v6" />
+                    <path d="M9 6V4h6v2" />
+                  </svg>
+                )}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- When user edits an AI-autofilled field and moves focus away, a small inline "Save as preference?" toast appears — non-blocking, doesn't interrupt form interaction
- Accepting saves the correction via `POST /api/corrections` (upserts into `FormMemory` with `fieldType="correction"`, `confidence=1.0`)
- Corrections are automatically used in future autofills — `getSuggestionsFromHistory` already queries `FormMemory` at step 1, so corrections (confidence=1.0) take priority over profile suggestions
- Profile page shows a "Saved corrections" section with all saved corrections, each deletable via `DELETE /api/corrections/[id]`
- No new DB migration — reuses the existing `FormMemory` table

## Test plan

- [ ] Open a form, click "Autofill from Profile" to populate fields
- [ ] Edit one of the autofilled fields and tab/click away — "Save as preference?" toast appears below the field
- [ ] Click Save — toast shows "Saved as preference" confirmation, then disappears
- [ ] Click Dismiss — toast disappears with no save
- [ ] Toast does not appear for fields filled from scratch (no AI autofill)
- [ ] Go to Profile page — "Saved corrections" section shows the saved correction
- [ ] Delete a correction — it disappears from the list
- [ ] Autofill a new form — the corrected value appears for the matching field label

🤖 Generated with [Claude Code](https://claude.com/claude-code)