### PR TITLE
fix(#231): Pro users see free tier quota due to wrong period end

### DIFF
--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -9,6 +9,15 @@ import * as React from "react";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://getformpilot.com";
 
+/** Extract subscription period end from item-level billing data (Stripe v21+) */
+function getSubscriptionPeriodEnd(sub: Stripe.Subscription): Date | null {
+  const firstItem = sub.items?.data?.[0];
+  if (firstItem?.current_period_end) {
+    return new Date(firstItem.current_period_end * 1000);
+  }
+  return null;
+}
+
 export async function POST(req: NextRequest) {
   const body = await req.text();
   const sig = req.headers.get("stripe-signature");
@@ -39,6 +48,10 @@ export async function POST(req: NextRequest) {
 
       if (!userId || !subscriptionId) break;
 
+      // Fetch the Stripe subscription to get the accurate period end
+      const stripeSub = await getStripe().subscriptions.retrieve(subscriptionId);
+      const periodEnd = getSubscriptionPeriodEnd(stripeSub);
+
       await prisma.subscription.upsert({
         where: { userId },
         create: {
@@ -46,10 +59,12 @@ export async function POST(req: NextRequest) {
           stripeCustomerId: session.customer as string,
           stripeSubscriptionId: subscriptionId,
           status: "ACTIVE",
+          ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
         },
         update: {
           stripeSubscriptionId: subscriptionId,
           status: "ACTIVE",
+          ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
         },
       });
 
@@ -78,10 +93,13 @@ export async function POST(req: NextRequest) {
       });
       if (!sub) break;
 
-      // Use invoice period_end as the subscription period end
-      const periodEnd = invoice.period_end
-        ? new Date(invoice.period_end * 1000)
-        : null;
+      // Fetch subscription's period end from Stripe (not invoice.period_end,
+      // which refers to the invoicing period and can be in the past)
+      let periodEnd: Date | null = null;
+      if (sub.stripeSubscriptionId) {
+        const stripeSubObj = await getStripe().subscriptions.retrieve(sub.stripeSubscriptionId);
+        periodEnd = getSubscriptionPeriodEnd(stripeSubObj);
+      }
 
       await prisma.subscription.update({
         where: { stripeCustomerId: customerId },
@@ -111,11 +129,14 @@ export async function POST(req: NextRequest) {
           ? "PAST_DUE"
           : "CANCELED";
 
+      const subPeriodEnd = getSubscriptionPeriodEnd(stripeSub);
+
       await prisma.subscription.updateMany({
         where: { stripeCustomerId: customerId },
         data: {
           status,
           stripeSubscriptionId: stripeSub.id,
+          ...(subPeriodEnd ? { currentPeriodEnd: subPeriodEnd } : {}),
         },
       });
       break;


### PR DESCRIPTION
## What
Fixed the Stripe webhook handler to correctly persist `currentPeriodEnd` from the subscription item's billing data (Stripe SDK v21+), so that `isProUser()` no longer incorrectly rejects active Pro subscriptions.

## Why
Closes #231

The dashboard displayed "5 of 5 forms used this month" with an "Upgrade to continue" link for Pro users because:

1. `checkout.session.completed` never set `currentPeriodEnd` at all
2. `invoice.paid` used `invoice.period_end` (the invoicing period end, which can be in the past) instead of the subscription's actual billing period end
3. `customer.subscription.updated` never persisted `currentPeriodEnd`

This caused `isProUser()` to see an expired `currentPeriodEnd` and return `false`, making the dashboard render free-tier quota UI.

## Acceptance Criteria
- [x] Pro users see "Unlimited plan -- no limits" instead of "X/5 forms"
- [x] "Upgrade" link hidden for Pro users
- [x] Free tier users still see quota correctly (no changes to QuotaBar/DashboardStats)

## Test Plan
1. Trigger a Stripe checkout completion webhook for a test user
2. Verify `currentPeriodEnd` is populated in the Subscription table with a future date
3. Confirm the dashboard shows "Pro" badge with "Unlimited plan -- no limits"
4. Verify a free-tier user still sees the quota bar with "X of 5 forms used"
5. Test `invoice.paid` webhook updates `currentPeriodEnd` from subscription item data

Generated with [Claude Code](https://claude.com/claude-code)