### PR TITLE
feat: add Batch Fill nav link to dashboard (#243)

### DIFF
--- a/src/components/DashboardNav.tsx
+++ b/src/components/DashboardNav.tsx
@@ -55,6 +55,17 @@ const NAV_ITEMS = [
     ),
   },
   {
+    href: "/dashboard/batch",
+    label: "Batch Fill",
+    icon: (
+      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2L2 7l10 5 10-5-10-5z" />
+        <path d="M2 17l10 5 10-5" />
+        <path d="M2 12l10 5 10-5" />
+      </svg>
+    ),
+  },
+  {
     href: "/dashboard/memory",
     label: "Memory",
     icon: (


### PR DESCRIPTION
## Summary
- Adds **Batch Fill** nav item to `DashboardNav.tsx` between Templates and Memory
- Uses a layers/stack SVG icon consistent with existing nav items
- Works for all users — the Pro gate already exists on the page itself
- Active-highlighted when on `/dashboard/batch`
- Visible in both desktop and mobile nav menus

## Test plan
- [ ] Navigate to dashboard — confirm "Batch Fill" appears in nav
- [ ] Click it — confirm route `/dashboard/batch` loads
- [ ] On `/dashboard/batch` — confirm nav item is highlighted blue
- [ ] Free user: confirm nav item visible, page shows Pro upsell
- [ ] Mobile: open hamburger menu, confirm Batch Fill appears

Fixes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)