### PR TITLE
fix(#244): wire Guided Fill Finish button to mark-as-complete flow

### DIFF
--- a/src/components/forms/FormPageClient.tsx
+++ b/src/components/forms/FormPageClient.tsx
@@ -247,6 +247,23 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, pr
     </nav>
   );
 
+  async function handleGuidedFinish() {
+    // Mark form as complete (same path as the "Mark as Complete" button in FormViewer)
+    await fetch(`/api/forms/${form.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "COMPLETED" }),
+    });
+
+    // Exit guided mode first so the overlay renders over the full form view
+    setMode("full");
+
+    // Show overlay only if not already celebrated
+    if (!localStorage.getItem(`fp_completed_${form.id}`)) {
+      setShowCompleteOverlay(true);
+    }
+  }
+
   if (mode === "guided") {
     return (
       <>
@@ -259,6 +276,7 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, pr
           initialStates={initialStates}
           hasProfile={hasProfile}
           onExit={() => setMode("full")}
+          onFinish={handleGuidedFinish}
           onValuesChange={handleValuesChange}
         />
       </>

--- a/src/components/forms/GuidedFillMode.tsx
+++ b/src/components/forms/GuidedFillMode.tsx
@@ -10,6 +10,8 @@ interface Props {
   initialStates: Record<string, FieldState>;
   hasProfile: boolean;
   onExit: () => void;
+  /** Called when the user presses "Finish" on the last step. Defaults to onExit if not provided. */
+  onFinish?: () => void;
   onValuesChange: (values: Record<string, string>, states: Record<string, FieldState>) => void;
 }
 
@@ -84,6 +86,7 @@ export default function GuidedFillMode({
   initialStates,
   hasProfile,
   onExit,
+  onFinish,
   onValuesChange,
 }: Props) {
   const groups = groupFields(fields);
@@ -504,7 +507,7 @@ export default function GuidedFillMode({
             </button>
           ) : (
             <button
-              onClick={onExit}
+              onClick={onFinish ?? onExit}
               className="inline-flex items-center justify-center gap-1.5 px-4 py-3 sm:py-2.5 min-h-[48px] sm:min-h-0 text-sm bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 transition-colors active:scale-[0.98]"
             >
               <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
## What
Wire the \"Finish\" button on the last Guided Fill step to the same mark-as-complete path used by the \"Mark as Complete\" button in `FormViewer`.

**Changes:**
- `GuidedFillMode.tsx`: Add optional `onFinish?: () => void` prop. The Finish button calls `onFinish ?? onExit` — preserving backward compatibility for any callers that don't pass `onFinish`.
- `FormPageClient.tsx`: Add `handleGuidedFinish` async function that:
  1. PATCHes `status: "COMPLETED"` to `/api/forms/[id]`
  2. Switches mode back to `"full"` (exits guided view)
  3. Shows `FormCompleteOverlay` — respecting the `fp_completed_${formId}` localStorage guard to avoid re-showing on repeat visits
- Pass `onFinish={handleGuidedFinish}` to `GuidedFillMode` in `FormPageClient`

The header \"Exit Guided Mode\" button is unchanged — it still calls `onExit` with no mark-as-complete side effect.

## Why
Closes #244

## Acceptance Criteria
- [x] Pressing \"Finish\" on the last Guided Fill step triggers the same mark-as-complete flow as the \"Mark as Complete\" button in full view
- [x] `FormCompleteOverlay` is shown after finish (triggered via the same `setShowCompleteOverlay(true)` mechanism used by the \"Mark as Complete\" button)
- [x] Form status is updated to `COMPLETED` via `PATCH /api/forms/[id]` (same as the existing flow)
- [x] If the form was already marked complete, the overlay does not show again (respects the `localStorage fp_completed_${formId}` guard already in place)
- [x] \"Finish\" in Guided Fill still exits guided mode (returns to full form view) after overlay is shown/dismissed

## Test Plan
1. Upload a form and open it
2. Click \"Start Guided Fill\"
3. Navigate through all steps to the last one
4. Click \"Finish\"
5. Verify: form status is COMPLETED (check network tab for PATCH request), `FormCompleteOverlay` appears with share/download CTA
6. Close the overlay — verify you land on the full form view
7. Reload the page and enter Guided Fill again, click Finish — verify overlay does NOT show a second time (localStorage guard)
8. Also verify: clicking \"Exit Guided Mode\" (header button on any step) returns to full view with no overlay and no COMPLETED PATCH

@qa-agent please review