### PR TITLE
feat(#247): Dashboard empty state with Try a sample form CTA

### DIFF
--- a/src/app/api/forms/sample/route.ts
+++ b/src/app/api/forms/sample/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { handleApiError } from "@/lib/api-error";
+import type { FormField } from "@/lib/ai/analyze-form";
+
+// Static fixture — a simplified W-4 Employee's Withholding Certificate.
+// Fields have pre-written explanations so the user lands on the fill view
+// immediately without any AI processing delay.
+const SAMPLE_FIELDS: FormField[] = [
+  {
+    id: "s1",
+    label: "First Name and Middle Initial",
+    type: "text",
+    required: true,
+    explanation: "Enter your legal first name as it appears on your Social Security card, followed by your middle initial if applicable.",
+    example: "Alex M",
+    commonMistakes: "Using a nickname instead of your legal first name.",
+    profileKey: "firstName",
+  },
+  {
+    id: "s2",
+    label: "Last Name",
+    type: "text",
+    required: true,
+    explanation: "Enter your legal last name exactly as it appears on your Social Security card.",
+    example: "Johnson",
+    commonMistakes: "Using a married name that hasn't been updated with the SSA yet.",
+    profileKey: "lastName",
+  },
+  {
+    id: "s3",
+    label: "Social Security Number",
+    type: "text",
+    required: true,
+    explanation: "Your 9-digit Social Security Number assigned by the Social Security Administration. Use the format XXX-XX-XXXX.",
+    example: "123-45-6789",
+    commonMistakes: "Transposing digits or leaving out dashes.",
+    profileKey: "ssn",
+  },
+  {
+    id: "s4",
+    label: "Home Address (Number and Street)",
+    type: "text",
+    required: true,
+    explanation: "Your current primary residence street address including house or apartment number.",
+    example: "456 Oak Avenue, Apt 2B",
+    commonMistakes: "Using a P.O. Box instead of a street address.",
+    profileKey: "address.street",
+  },
+  {
+    id: "s5",
+    label: "City or Town",
+    type: "text",
+    required: true,
+    explanation: "The city or town where you currently reside.",
+    example: "Springfield",
+    commonMistakes: "Including the state name here — that goes in the next field.",
+    profileKey: "address.city",
+  },
+  {
+    id: "s6",
+    label: "State",
+    type: "text",
+    required: true,
+    explanation: "The two-letter state abbreviation for your current state of residence.",
+    example: "IL",
+    commonMistakes: "Writing the full state name instead of the two-letter abbreviation.",
+    profileKey: "address.state",
+  },
+  {
+    id: "s7",
+    label: "ZIP Code",
+    type: "text",
+    required: true,
+    explanation: "Your 5-digit or 9-digit ZIP code (ZIP+4 format) for your home address.",
+    example: "62701",
+    commonMistakes: "Using your employer's ZIP code instead of your home ZIP.",
+    profileKey: "address.zip",
+  },
+  {
+    id: "s8",
+    label: "Filing Status",
+    type: "select",
+    required: true,
+    explanation: "Your federal tax filing status. Choose 'Single or Married filing separately', 'Married filing jointly', or 'Head of household'. This affects how much tax is withheld each pay period.",
+    example: "Single or Married filing separately",
+    commonMistakes: "Selecting 'Married filing jointly' when you file separately, which results in too little withholding.",
+  },
+];
+
+// POST /api/forms/sample — creates a demo W-4 form from static fixture.
+// Does NOT increment the user's monthly quota — this is a free demo.
+export async function POST() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const form = await prisma.form.create({
+      data: {
+        userId: session.user.id,
+        title: "Sample — W-4 Demo",
+        sourceType: "PDF",
+        fields: SAMPLE_FIELDS as unknown as Parameters<typeof prisma.form.create>[0]["data"]["fields"],
+        category: "TAX",
+        status: "ANALYZED",
+        // fileBytes intentionally omitted — no real PDF backing this demo form
+      },
+    });
+
+    // Quota is intentionally NOT incremented — sample form is a free demo experience.
+
+    return NextResponse.json({ formId: form.id }, { status: 201 });
+  } catch (err) {
+    return handleApiError(err, "POST /api/forms/sample");
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import FormCardList from "@/components/forms/FormCardList";
+import DashboardEmptyState from "@/components/forms/DashboardEmptyState";
 import OnboardingChecklist from "@/components/OnboardingChecklist";
 import DashboardStats from "@/components/DashboardStats";
 import QuotaBar from "@/components/QuotaBar";
@@ -160,31 +161,7 @@ export default async function DashboardPage() {
 
         {/* Content */}
         {pagedForms.length === 0 ? (
-          <div className="bg-white rounded-2xl border border-slate-200 shadow-soft p-12 sm:p-16 text-center">
-            <div className="mx-auto w-16 h-16 rounded-2xl bg-blue-50 flex items-center justify-center mb-6">
-              <svg className="w-8 h-8 text-blue-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
-                <polyline points="14 2 14 8 20 8" />
-                <line x1="12" y1="18" x2="12" y2="12" />
-                <line x1="9" y1="15" x2="12" y2="12" />
-                <line x1="15" y1="15" x2="12" y2="12" />
-              </svg>
-            </div>
-            <h2 className="text-lg font-semibold text-slate-900">Fill your first form</h2>
-            <p className="text-slate-500 mt-2 max-w-sm mx-auto text-sm">
-              Upload any PDF, Word doc, or photo of a paper form — FormPilot will explain every field and help you fill it.
-            </p>
-            <Link
-              href="/dashboard/upload"
-              className="inline-flex items-center gap-2 mt-6 px-6 py-2.5 bg-blue-600 text-white rounded-xl text-sm font-semibold hover:bg-blue-700 transition-all shadow-sm active:scale-[0.98]"
-            >
-              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <line x1="12" y1="5" x2="12" y2="19" />
-                <line x1="5" y1="12" x2="19" y2="12" />
-              </svg>
-              Upload a Form
-            </Link>
-          </div>
+          <DashboardEmptyState />
         ) : (
           <FormCardList
             initialHasMore={hasMore}

--- a/src/components/forms/DashboardEmptyState.tsx
+++ b/src/components/forms/DashboardEmptyState.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function DashboardEmptyState() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleTrySample() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/forms/sample", { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        throw new Error(data.error ?? "Failed to create sample form");
+      }
+      const data = await res.json() as { formId: string };
+      router.push(`/dashboard/forms/${data.formId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 shadow-soft p-12 sm:p-16 text-center">
+      {/* Icon */}
+      <div className="mx-auto w-16 h-16 rounded-2xl bg-blue-50 flex items-center justify-center mb-6">
+        <svg
+          className="w-8 h-8 text-blue-500"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="12" y1="18" x2="12" y2="12" />
+          <line x1="9" y1="15" x2="12" y2="12" />
+          <line x1="15" y1="15" x2="12" y2="12" />
+        </svg>
+      </div>
+
+      {/* Copy */}
+      <h2 className="text-lg font-semibold text-slate-900">
+        You haven&apos;t uploaded any forms yet
+      </h2>
+      <p className="text-slate-500 mt-2 max-w-sm mx-auto text-sm">
+        Upload any PDF, Word doc, or photo of a paper form — FormPilot will explain every field and help you fill it.
+      </p>
+
+      {/* CTAs */}
+      <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+        <Link
+          href="/dashboard/upload"
+          className="inline-flex items-center gap-2 px-6 py-2.5 bg-blue-600 text-white rounded-xl text-sm font-semibold hover:bg-blue-700 transition-all shadow-sm active:scale-[0.98]"
+        >
+          <svg
+            className="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          Upload your first form
+        </Link>
+
+        <button
+          onClick={handleTrySample}
+          disabled={loading}
+          className="inline-flex items-center gap-2 px-6 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl text-sm font-semibold hover:bg-slate-50 hover:border-slate-300 transition-all shadow-sm active:scale-[0.98] disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {loading ? (
+            <>
+              <svg
+                className="w-4 h-4 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+                <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
+              </svg>
+              Loading demo…
+            </>
+          ) : (
+            <>
+              <svg
+                className="w-4 h-4 text-slate-500"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <polygon points="5 3 19 12 5 21 5 3" />
+              </svg>
+              Try a sample form
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Sample form hint */}
+      <p className="mt-4 text-xs text-slate-400">
+        Sample is a W-4 demo — pre-analyzed, no quota used
+      </p>
+
+      {/* Error */}
+      {error && (
+        <p role="alert" className="mt-4 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

- New `DashboardEmptyState` client component replaces the old inline empty-state block in `dashboard/page.tsx`
- Empty state shows: icon, headline ("You haven't uploaded any forms yet"), primary CTA "Upload your first form" (links to `/dashboard/upload`), secondary CTA "Try a sample form"
- New `POST /api/forms/sample` route creates a pre-analyzed 8-field W-4 demo form from a static in-memory fixture — no AI call, no quota increment
- "Try a sample form" button shows a spinner while creating the form, then redirects the user directly to the fill view (`/dashboard/forms/[id]`)
- Sample form is labeled "Sample — W-4 Demo" with category TAX and status ANALYZED so the user lands on the fill view immediately
- Once the user has any form, `pagedForms.length > 0` and the normal `FormCardList` renders — empty state never appears again

## Why

Closes #247

## Acceptance Criteria

- [x] Dashboard form list shows a dedicated empty state UI when user has zero forms
- [x] Empty state includes: icon, headline, "Upload your first form" CTA, "Try a sample form" secondary CTA
- [x] "Try a sample form" creates a form and navigates to it
- [x] Sample form creation does not increment the user's monthly quota counter
- [x] Once user has at least one real form, the empty state never appears again
- [x] Sample form is clearly labeled "Sample — W-4 Demo"
- [x] Sample form is pre-analyzed (status=ANALYZED) so user lands directly on fill view

## Decisions

- Used a new `POST /api/forms/sample` endpoint (not the existing template endpoint) — cleaner because it avoids needing a real `sourceFormId` for the template record, and the static fixture lives entirely in code with no DB seed required
- Static 8-field W-4 fixture defined in the route file — no PDF bundling needed since `fileBytes` is optional in the schema
- Quota increment deliberately omitted with an inline comment explaining why

## Test Plan

1. Sign in as a user with zero forms
2. Navigate to `/dashboard` — should see the empty state with both CTAs
3. Click "Try a sample form" — button shows spinner, then redirects to form detail page
4. Verify the form is titled "Sample — W-4 Demo" with 8 fields visible, status "Ready to Fill"
5. Verify the user's quota counter was NOT incremented (check `/api/usage` or the QuotaBar after returning to dashboard)
6. Upload a real form — verify the empty state no longer appears