### PR TITLE
fix(#245): add OG/Twitter card metadata to template share pages

### DIFF
--- a/src/app/t/[slug]/page.tsx
+++ b/src/app/t/[slug]/page.tsx
@@ -13,7 +13,24 @@ export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
   const template = await prisma.formTemplate.findUnique({ where: { slug } });
   if (!template || template.revokedAt) return { title: "Template not found — FormPilot" };
-  return { title: `${template.name} — FormPilot` };
+  const description = `Fill the ${template.name} with AI guidance and auto-fill from your profile — powered by FormPilot`;
+  const ogImage = "/og-image.png";
+  return {
+    title: `${template.name} — FormPilot`,
+    description,
+    openGraph: {
+      type: "website",
+      title: `${template.name} — FormPilot`,
+      description,
+      images: [{ url: ogImage, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${template.name} — FormPilot`,
+      description,
+      images: [ogImage],
+    },
+  };
 }
 
 export default async function TemplatePage({ params }: Props) {


### PR DESCRIPTION
## Summary
- `generateMetadata` in `src/app/t/[slug]/page.tsx` now returns full OG + Twitter card metadata
- Description: "Fill the [Form Name] with AI guidance and auto-fill from your profile — powered by FormPilot"
- Image: `/og-image.png` (1200×630)
- Not-found case unchanged (no image reference to break)

## Test plan
- [ ] Share a template URL in Slack — confirm image + description appear in preview
- [ ] Paste URL on Twitter/X — confirm summary_large_image card renders
- [ ] Invalid slug — confirm page 404s cleanly

Fixes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)