### PR TITLE
feat: Jump-to-unfilled field button on form detail page (#246)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,6 +103,17 @@ html {
   border-radius: 8px;
 }
 
+/* Jump-to-field highlight ring pulse */
+@keyframes field-highlight-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.45); }
+  50% { box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.15); }
+  100% { box-shadow: 0 0 0 0 rgba(37, 99, 235, 0); }
+}
+
+.field-highlight {
+  animation: field-highlight-pulse 0.9s ease-out forwards;
+}
+
 /* Drag and drop styles */
 .drop-zone-active {
   border-color: #2563eb !important;

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -118,6 +118,8 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   );
   // keyboard navigation for unanswered fields
   const [currentUnansweredIndex, setCurrentUnansweredIndex] = useState(0);
+  // field currently flashing the highlight ring (cleared after animation ends)
+  const [highlightedFieldId, setHighlightedFieldId] = useState<string | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const titleSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -533,27 +535,31 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
 
   // -- keyboard navigation --
 
-  // Get list of unanswered field IDs (fields with no value)
+  // Get list of unfilled field IDs: no value AND fieldState is not "accepted"
   const unansweredFieldIds = fields
-    .filter((f) => !values[f.id])
+    .filter((f) => (!values[f.id] || values[f.id] === "") && fieldStates[f.id] !== "accepted")
     .map((f) => f.id);
 
   const unansweredCount = unansweredFieldIds.length;
 
-  // Navigate to an unanswered field by index
+  // Navigate to an unanswered field by index (wraps around)
   const navigateToUnansweredField = useCallback((index: number) => {
     if (unansweredFieldIds.length === 0) return;
-    const clampedIndex = Math.max(0, Math.min(index, unansweredFieldIds.length - 1));
-    setCurrentUnansweredIndex(clampedIndex);
-    const fieldId = unansweredFieldIds[clampedIndex];
+    // Wrap-around
+    const wrappedIndex = ((index % unansweredFieldIds.length) + unansweredFieldIds.length) % unansweredFieldIds.length;
+    setCurrentUnansweredIndex(wrappedIndex);
+    const fieldId = unansweredFieldIds[wrappedIndex];
     const element = document.getElementById(`field-${fieldId}`);
     if (element) {
       element.scrollIntoView({ behavior: "smooth", block: "center" });
       element.focus();
     }
+    // Trigger highlight ring animation — clear first to allow re-trigger on same field
+    setHighlightedFieldId(null);
+    requestAnimationFrame(() => setHighlightedFieldId(fieldId));
   }, [unansweredFieldIds]);
 
-  // Handle keyboard shortcuts: Alt+N (next), Alt+P (previous)
+  // Handle keyboard shortcuts: Alt+N / Alt+P (legacy) + N / ] when not in an input
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (unansweredCount === 0) return;
@@ -561,9 +567,23 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
       if (e.altKey && e.key === "n") {
         e.preventDefault();
         navigateToUnansweredField(currentUnansweredIndex + 1);
-      } else if (e.altKey && e.key === "p") {
+        return;
+      }
+      if (e.altKey && e.key === "p") {
         e.preventDefault();
         navigateToUnansweredField(currentUnansweredIndex - 1);
+        return;
+      }
+
+      // N or ] advances to next empty field — but only when focus is NOT inside a text input/textarea/select
+      const tag = (e.target as HTMLElement)?.tagName;
+      const isEditable = (e.target as HTMLElement)?.isContentEditable;
+      const isInputFocused = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || isEditable;
+      if (!isInputFocused && !e.altKey && !e.ctrlKey && !e.metaKey) {
+        if (e.key === "n" || e.key === "N" || e.key === "]") {
+          e.preventDefault();
+          navigateToUnansweredField(currentUnansweredIndex + 1);
+        }
       }
     };
 
@@ -790,6 +810,23 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
           </div>
 
           <div className="flex flex-wrap gap-2">
+            {/* Jump to next empty field */}
+            {unansweredCount > 0 && (
+              <button
+                type="button"
+                onClick={() => navigateToUnansweredField(currentUnansweredIndex)}
+                className="inline-flex items-center gap-1.5 px-4 py-2 border border-blue-200 bg-blue-50 text-blue-700 text-sm rounded-lg font-medium hover:bg-blue-100 transition-colors active:scale-[0.98]"
+                aria-label={`Jump to next empty field. ${unansweredCount} empty field${unansweredCount === 1 ? "" : "s"} remaining.`}
+                title="Jump to next empty field (press N or ] when not typing)"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 8 16 12 12 16" />
+                  <line x1="8" y1="12" x2="16" y2="12" />
+                </svg>
+                {unansweredCount} empty field{unansweredCount === 1 ? "" : "s"}
+              </button>
+            )}
             {/* Sample fill button */}
             <button
               onClick={handleSampleFill}
@@ -1160,10 +1197,15 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
           const fieldErrors = validation?.errors.filter((e) => e.fieldId === field.id) ?? [];
           const fieldWarnings = validation?.warnings.filter((w) => w.fieldId === field.id && w.rule === "low_confidence") ?? [];
 
+          const isHighlighted = highlightedFieldId === field.id;
+
           return (
             <div
               key={field.id}
-              className={`rounded-2xl border transition-all shadow-soft ${cardClasses}`}
+              className={`rounded-2xl border transition-all shadow-soft ${cardClasses}${isHighlighted ? " field-highlight" : ""}`}
+              onAnimationEnd={() => {
+                if (isHighlighted) setHighlightedFieldId(null);
+              }}
             >
               <div className="p-5 space-y-3">
                 {/* Top row: label + actions */}


### PR DESCRIPTION
## What

Adds a \"Next empty field\" navigation button to the `FormViewer` toolbar that lets users jump directly to the next unfilled field — without manually scrolling through long forms.

## Why

Closes #246

On complex forms (W-4, I-9, DS-160 with 20–40+ fields), users had no way to navigate directly to unfilled fields after autofill. This adds that navigation affordance.

## Acceptance Criteria

- [x] A button appears in the toolbar showing the count of remaining empty fields (e.g. \"3 empty fields\")
- [x] Button is hidden when all fields are filled
- [x] Button scrolls to and highlights the next unfilled field with a blue ring-pulse animation
- [x] Navigation wraps around to the first empty field when reaching the end of the list
- [x] Unfilled = value is empty/null AND fieldState is not \"accepted\"
- [x] Keyboard shortcut: `N` or `]` advances to next empty field when focus is not inside an input
- [x] Legacy `Alt+N` / `Alt+P` shortcuts preserved

## Implementation Notes

- CSS: `field-highlight-pulse` keyframe added to `globals.css` — 0.9s blue ring animation, cleared on `animationEnd`
- `navigateToUnansweredField` now wraps around using modulo arithmetic instead of clamping
- Highlight re-triggers correctly on repeated presses of the same field (clear + `requestAnimationFrame`)
- TypeScript: `tsc --noEmit` passed with zero errors

## Test Plan

1. Open a form with several unfilled fields
2. Verify the blue \"N empty fields\" button appears in the toolbar
3. Click it — page should scroll to the first empty field and flash a blue ring
4. Click again — should advance to the next empty field
5. Keep clicking until wrap-around (last → first)
6. Fill all fields — button should disappear
7. Press `N` key (focus not in an input) — should also navigate

@qa-agent please review