### PR TITLE
feat(#253): delete form — quota decrement, template revocation, toast

### DIFF
--- a/src/app/api/forms/[id]/route.ts
+++ b/src/app/api/forms/[id]/route.ts
@@ -8,6 +8,7 @@ import FormCompletedEmail from "@/emails/FormCompletedEmail";
 import type { FormField } from "@/lib/ai/analyze-form";
 import { z } from "zod";
 import * as React from "react";
+import { resetMonthlyUsage, getOrCreateUsage } from "@/lib/subscription";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://getformpilot.com";
 
@@ -57,7 +58,22 @@ export async function DELETE(
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
+    // Revoke any templates created from this form so shared links show a graceful page
+    await prisma.formTemplate.updateMany({
+      where: { sourceFormId: id, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+
     await prisma.form.delete({ where: { id } });
+
+    // Decrement monthly usage so the user gets their slot back
+    const usage = await getOrCreateUsage(session.user.id);
+    if (usage.formsThisMonth > 0) {
+      await prisma.usageCount.update({
+        where: { userId: session.user.id },
+        data: { formsThisMonth: { decrement: 1 }, updatedAt: new Date() },
+      });
+    }
 
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (err) {

--- a/src/app/t/[slug]/page.tsx
+++ b/src/app/t/[slug]/page.tsx
@@ -37,8 +37,29 @@ export default async function TemplatePage({ params }: Props) {
   const { slug } = await params;
   const template = await prisma.formTemplate.findUnique({ where: { slug } });
 
-  if (!template || template.revokedAt) {
+  if (!template) {
     notFound();
+  }
+
+  if (template.revokedAt) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center px-4">
+        <div className="max-w-md w-full text-center space-y-4">
+          <div className="w-14 h-14 rounded-2xl bg-slate-100 flex items-center justify-center mx-auto">
+            <svg className="w-7 h-7 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="9" y1="15" x2="15" y2="15" />
+            </svg>
+          </div>
+          <h1 className="text-xl font-semibold text-slate-900">This form is no longer available</h1>
+          <p className="text-sm text-slate-500">The owner has removed this form. If you need access, please contact them directly.</p>
+          <Link href="/" className="inline-flex items-center gap-2 text-sm font-medium text-blue-600 hover:text-blue-700">
+            Go to FormPilot
+          </Link>
+        </div>
+      </div>
+    );
   }
 
   const fields = template.fields as unknown as FormField[];

--- a/src/components/forms/FormCardList.tsx
+++ b/src/components/forms/FormCardList.tsx
@@ -87,6 +87,7 @@ export default function FormCardList({ forms: initialForms, initialHasMore = fal
   const router = useRouter();
   const [forms, setForms] = useState(initialForms);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
@@ -127,9 +128,12 @@ export default function FormCardList({ forms: initialForms, initialHasMore = fal
         throw new Error(data.error ?? "Delete failed");
       }
       setForms((prev) => prev.filter((f) => f.id !== id));
+      setToast("Form deleted");
+      setTimeout(() => setToast(null), 3000);
       router.refresh();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Could not delete form");
+      setToast(err instanceof Error ? err.message : "Could not delete form");
+      setTimeout(() => setToast(null), 4000);
     } finally {
       setDeletingId(null);
     }
@@ -357,6 +361,13 @@ export default function FormCardList({ forms: initialForms, initialHasMore = fal
               </div>
             );
           })}
+        </div>
+      )}
+
+      {/* Toast notification */}
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-2.5 bg-slate-900 text-white text-sm font-medium rounded-xl shadow-lg animate-fade-in">
+          {toast}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- `DELETE /api/forms/[id]` now revokes associated templates (sets `revokedAt`) and decrements `formsThisMonth` so deleted forms return their quota slot
- `/t/[slug]` now shows a graceful "This form is no longer available" page for revoked templates instead of a raw 404
- `FormCardList` replaces `alert()` / silent success with a bottom toast notification ("Form deleted" / error message)

## What was already there
- Delete button (hover-reveal trash icon on each form card)
- `window.confirm()` modal
- `DELETE /api/forms/[id]` API endpoint

## Test plan
- [ ] Upload a form → hover card → click trash → confirm → "Form deleted" toast appears, card disappears
- [ ] Check billing page — quota count decremented by 1
- [ ] Create a template from a form → delete the form → visit the template link → see graceful revoked page
- [ ] Cancel confirmation → form not deleted

Fixes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)