### PR TITLE
fix(#257): guard quota-approaching email against Pro users

### DIFF
--- a/src/app/api/forms/upload/route.ts
+++ b/src/app/api/forms/upload/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { canUploadForm, incrementFormUsage } from "@/lib/subscription";
+import { canUploadForm, incrementFormUsage, isProUser } from "@/lib/subscription";
 import { extractTextFromBuffer } from "@/lib/pdf/extract";
 import { analyzeFormFields, analyzeFormFieldsFromImage } from "@/lib/ai/analyze-form";
 import { preprocessImage } from "@/lib/image/preprocess";
@@ -208,7 +208,8 @@ export async function POST(req: NextRequest) {
     incrementFormUsage(session.user.id).then(async () => {
       // After incrementing, check if user has hit the quota-nudge threshold (4/5 forms)
       // Only fires once per billing period via quotaNudgeSentAt guard
-      if (session.user.email) {
+      // Skip entirely for Pro users — they have no quota cap
+      if (session.user.email && !(await isProUser(session.user.id))) {
         try {
           const usage = await prisma.usageCount.findUnique({ where: { userId: session.user.id } });
           const FREE_LIMIT = 5;


### PR DESCRIPTION
## What

Verified the quota-approaching email (80% free tier usage) is fully implemented and wired up. Added a missing Pro user guard to ensure the nudge email is never sent to Pro subscribers.

**Existing implementation (already in main):**
- `src/emails/QuotaApproachingEmail.tsx` — email template with usage count, remaining forms, upgrade CTA, and direct billing link
- `prisma/schema.prisma` — `UsageCount.quotaNudgeSentAt DateTime?` field for once-per-period deduplication
- `src/app/api/forms/upload/route.ts` — trigger fires after `incrementFormUsage()` when `formsThisMonth >= 4 && < 5 && !quotaNudgeSentAt`

**This PR adds:**
- `isProUser()` import and guard in the nudge trigger so Pro users (no quota cap) are never sent a free-tier warning

## Why

Closes #257

## Acceptance Criteria

- [x] Quota check logic located: `src/app/api/forms/upload/route.ts` lines 208–243
- [x] Email triggers when free-tier user hits 4/5 forms in the current billing period
- [x] Sends only once per billing period (`quotaNudgeSentAt` deduplication)
- [x] Email subject includes remaining count; body has usage count, upgrade CTA, and direct `/dashboard/billing` link
- [x] Email is not sent to Pro users (added `isProUser()` guard in this PR)
- [x] TypeScript: `npx tsc --noEmit` — zero errors

## Test Plan

1. Create a free account
2. Upload 3 forms (no email expected)
3. Upload the 4th form — quota-approaching email should arrive with subject "You have 1 free form left this month"
4. Upload a 5th form — no second nudge email (deduplication via `quotaNudgeSentAt`)
5. Confirm Pro users receive no quota nudge email after upgrading