### PR TITLE
feat: auto-save indicator on form fill page (#254)

### DIFF
--- a/src/components/forms/AutoSaveIndicator.tsx
+++ b/src/components/forms/AutoSaveIndicator.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+interface Props {
+  status: SaveStatus;
+  savedAt: Date | null;
+  onDismissError?: () => void;
+}
+
+function computeRelativeTime(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 10) return "Saved just now";
+  if (diffSec < 60) return `Saved ${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin === 1) return "Saved 1 min ago";
+  if (diffMin < 60) return `Saved ${diffMin} min ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr === 1) return "Saved 1 hr ago";
+  return `Saved ${diffHr} hr ago`;
+}
+
+function useRelativeTime(date: Date | null): string {
+  const [label, setLabel] = useState(() => (date ? computeRelativeTime(date) : ""));
+
+  useEffect(() => {
+    if (!date) {
+      setLabel("");
+      return;
+    }
+
+    setLabel(computeRelativeTime(date));
+
+    // Tick every 15 seconds to keep the label fresh
+    const interval = setInterval(() => setLabel(computeRelativeTime(date)), 15_000);
+    return () => clearInterval(interval);
+  }, [date]);
+
+  return label;
+}
+
+export default function AutoSaveIndicator({ status, savedAt, onDismissError }: Props) {
+  const relativeTime = useRelativeTime(savedAt);
+
+  if (status === "idle" && !savedAt) return null;
+
+  if (status === "saving") {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 text-xs text-slate-400"
+        aria-live="polite"
+        aria-label="Saving changes"
+      >
+        <svg
+          className="w-3.5 h-3.5 animate-spin shrink-0"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="3"
+            className="opacity-25"
+          />
+          <path
+            d="M4 12a8 8 0 018-8"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            className="opacity-75"
+          />
+        </svg>
+        Saving...
+      </span>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 text-xs text-amber-600"
+        aria-live="assertive"
+        role="alert"
+      >
+        <svg
+          className="w-3.5 h-3.5 shrink-0"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+        <span>Save failed — retrying</span>
+        {onDismissError && (
+          <button
+            type="button"
+            onClick={onDismissError}
+            className="ml-1 text-amber-500 hover:text-amber-700 transition-colors"
+            aria-label="Dismiss save error"
+          >
+            <svg
+              className="w-3 h-3"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        )}
+      </span>
+    );
+  }
+
+  // "saved" or idle-but-has-savedAt
+  if (savedAt && relativeTime) {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 text-xs text-emerald-600"
+        aria-live="polite"
+        aria-label={relativeTime}
+      >
+        <svg
+          className="w-3.5 h-3.5 shrink-0"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+        {relativeTime}
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/src/components/forms/FormPageClient.tsx
+++ b/src/components/forms/FormPageClient.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import FormViewer from "./FormViewer";
 import GuidedFillMode from "./GuidedFillMode";
 import FormCompleteOverlay from "./FormCompleteOverlay";
+import AutoSaveIndicator, { type SaveStatus } from "./AutoSaveIndicator";
 
 // pdf.js uses DOMMatrix at module-level — must be client-only (no SSR)
 const DocumentImageViewer = dynamic(() => import("./DocumentImageViewer"), { ssr: false });
@@ -71,6 +72,20 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, pr
   }, []);
   const [showCompleteOverlay, setShowCompleteOverlay] = useState(false);
   const [jumpToFieldRequest, setJumpToFieldRequest] = useState<{ fieldId: string; nonce: number } | null>(null);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>(() =>
+    (form.fields as FormField[]).some((f) => f.value) ? "saved" : "idle"
+  );
+  const [savedAt, setSavedAt] = useState<Date | null>(() =>
+    (form.fields as FormField[]).some((f) => f.value) ? new Date() : null
+  );
+
+  const handleSaveStatusChange = useCallback(
+    (status: SaveStatus, ts: Date | null) => {
+      setSaveStatus(status);
+      if (ts) setSavedAt(ts);
+    },
+    []
+  );
 
   // Check if this form has already been celebrated (prevents re-show on reload)
   useEffect(() => {
@@ -343,6 +358,13 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, pr
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Auto-save indicator */}
+          <AutoSaveIndicator
+            status={saveStatus}
+            savedAt={savedAt}
+            onDismissError={() => setSaveStatus("idle")}
+          />
+
           {/* Share as Template */}
           <button
             onClick={handleShare}
@@ -468,6 +490,7 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, pr
                 }
               }}
               language={activeLanguage}
+              onSaveStatusChange={handleSaveStatusChange}
             />
           </div>
           {/* Right: Document panel — sticky, desktop only */}
@@ -527,6 +550,7 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, pr
               }
             }}
             language={activeLanguage}
+            onSaveStatusChange={handleSaveStatusChange}
           />
         </div>
       )}

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -35,6 +35,8 @@ interface Props {
   jumpToFieldRequest?: { fieldId: string; nonce: number } | null;
   /** Active language code for translations. */
   language?: string;
+  /** Called whenever the save status changes — passes status and the timestamp of the last successful save. */
+  onSaveStatusChange?: (status: "idle" | "saving" | "saved" | "error", savedAt: Date | null) => void;
 }
 
 // -- helpers --
@@ -71,7 +73,7 @@ const tierConfig = {
 
 // -- component --
 
-export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChange, hasFile, sourceType, onTitleChange, onComplete }: Props) {
+export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChange, hasFile, sourceType, onTitleChange, onComplete, onSaveStatusChange }: Props) {
   const initialFields = form.fields as FormField[];
 
   const [fields] = useState<FormField[]>(initialFields);
@@ -92,6 +94,10 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   const [exporting, setExporting] = useState(false);
   const [activeField, setActiveField] = useState<string | null>(null);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [savedAt, setSavedAt] = useState<Date | null>(() =>
+    // If the form already has field values on mount, treat it as already saved
+    (form.fields as FormField[]).some((f) => f.value) ? new Date() : null
+  );
   const [validation, setValidation] = useState<ValidationResult | null>(null);
   const [showForceExportDialog, setShowForceExportDialog] = useState(false);
   const [showPreviewModal, setShowPreviewModal] = useState(false);
@@ -124,12 +130,22 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   const titleInputRef = useRef<HTMLInputElement>(null);
   const titleSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Notify parent of initial saved state on mount (if the form already has values)
+  useEffect(() => {
+    if (savedAt) {
+      onSaveStatusChange?.("saved", savedAt);
+    }
+    // Only run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // -- persistence --
 
   const scheduleSave = useCallback(
     (newValues: Record<string, string>, newStates: Record<string, FieldState>) => {
       if (saveTimer.current) clearTimeout(saveTimer.current);
       setSaveStatus("saving");
+      onSaveStatusChange?.("saving", null);
       saveTimer.current = setTimeout(async () => {
         try {
           const allFieldIds = new Set([
@@ -146,15 +162,19 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ fields: fieldUpdates, status: "FILLING" }),
           });
+          const now = new Date();
           setSaveStatus("saved");
+          setSavedAt(now);
           setSaveError(false);
+          onSaveStatusChange?.("saved", now);
         } catch {
           setSaveStatus("error");
           setSaveError(true);
+          onSaveStatusChange?.("error", null);
         }
       }, 800);
     },
-    [form.id]
+    [form.id, onSaveStatusChange]
   );
 
   // -- field actions --
@@ -353,6 +373,7 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
 
     setEditingTitle(false);
     setSaveStatus("saving");
+    onSaveStatusChange?.("saving", null);
 
     try {
       const res = await fetch(`/api/forms/${form.id}`, {
@@ -369,7 +390,10 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
       onTitleChange?.(trimmed);
 
       // Show "Saved" confirmation
+      const now = new Date();
       setSaveStatus("saved");
+      setSavedAt(now);
+      onSaveStatusChange?.("saved", now);
       if (titleSaveTimer.current) clearTimeout(titleSaveTimer.current);
       titleSaveTimer.current = setTimeout(() => setSaveStatus("idle"), 2000);
     } catch {


### PR DESCRIPTION
## What

Adds a visible auto-save status indicator to the mode toggle bar on the form fill page. The indicator is powered by a new `AutoSaveIndicator` component and a bubbled `onSaveStatusChange` callback from `FormViewer`.

States:
- **Saving...** — spinner shown immediately when a field change is debounced (800ms)
- **Saved just now / Saved N min ago** — checkmark with a live-updating relative timestamp (ticks every 15 seconds)
- **Save failed — retrying** — warning icon with a dismiss (x) button; does not block the form

## Why

Closes #254

## Acceptance Criteria

- [x] Save-status indicator is visible in the mode toggle bar (top of the field list area)
- [x] Indicator shows "Saving..." during the debounce window, "Saved just now" after success
- [x] Timestamp updates live: "Saved just now" → "Saved 45s ago" → "Saved 2 min ago"
- [x] On page load with existing field values, indicator immediately shows "Saved just now"
- [x] "Save failed — retrying" state is dismissible via the x button
- [x] Error state does not block form interaction
- [x] No interference with mobile layout (indicator sits inline in the flex-wrap toolbar)

## Test Plan

1. Open a form with existing field values — indicator should show "Saved just now" in the toolbar
2. Edit a field — indicator should switch to "Saving..." for ~800ms, then back to "Saved just now"
3. Wait 1–2 minutes — label should update to "Saved 1 min ago" / "Saved 2 min ago"
4. Open a fresh form with no values — indicator should be hidden until the first save
5. Simulate network error (DevTools offline) → edit a field → indicator shows "Save failed — retrying" → click x → indicator dismisses