### PR TITLE
feat: optimise demo-to-signup conversion path

### DIFF
--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { generateSampleValue } from "@/lib/sample-data";
+import DemoNudgeBanner from "@/components/forms/DemoNudgeBanner";
 
 interface DemoField {
   id: string;
@@ -145,7 +146,7 @@ export default function DemoPage() {
               Sign In
             </Link>
             <Link
-              href="/dashboard"
+              href="/login?from=demo"
               className="px-4 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors shadow-sm"
             >
               Get Started
@@ -155,25 +156,8 @@ export default function DemoPage() {
       </nav>
 
       <div className="max-w-3xl mx-auto px-4 sm:px-6 py-10 sm:py-14">
-        {/* Signup nudge banner */}
-        <div className="mb-8 flex flex-col sm:flex-row items-center justify-between gap-4 bg-blue-600 rounded-2xl px-5 py-4 shadow-md">
-          <div>
-            <p className="text-white font-semibold text-sm">
-              This is a live demo — no account needed.
-            </p>
-            <p className="text-blue-100 text-xs mt-0.5">
-              Sign up to upload your own forms and save your profile for instant
-              autofill.
-            </p>
-          </div>
-          <Link
-            href="/dashboard"
-            className="shrink-0 inline-flex items-center gap-2 px-4 py-2.5 bg-white text-blue-700 text-sm font-semibold rounded-xl hover:bg-blue-50 transition-colors shadow-sm"
-          >
-            Sign up to fill your own forms
-            <ArrowRightIcon />
-          </Link>
-        </div>
+        {/* Signup nudge banner — dynamic copy after user scrolls into the demo */}
+        <DemoNudgeBanner />
 
         {/* Form header */}
         <div className="mb-6">
@@ -307,10 +291,10 @@ export default function DemoPage() {
           </p>
           <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
             <Link
-              href="/dashboard"
+              href="/login?from=demo"
               className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-xl text-sm font-semibold hover:bg-blue-700 transition-all shadow-md active:scale-[0.98]"
             >
-              Sign up to fill your own forms
+              Create your free account
               <ArrowRightIcon />
             </Link>
             <Link

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,14 @@
 import { signIn } from "@/lib/auth";
 import Link from "next/link";
 
-export default function LoginPage() {
+interface Props {
+  searchParams: Promise<{ from?: string }>;
+}
+
+export default async function LoginPage({ searchParams }: Props) {
+  const { from } = await searchParams;
+  const isFromDemo = from === "demo";
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-white to-slate-50 px-4">
       <div className="w-full max-w-sm space-y-8">
@@ -15,9 +22,18 @@ export default function LoginPage() {
               Form<span className="text-blue-600">Pilot</span>
             </Link>
             <p className="text-slate-500 mt-2 text-sm">
-              Sign in to start filling forms with AI
+              {isFromDemo
+                ? "Create your account to save and fill your own forms"
+                : "Sign in to start filling forms with AI"}
             </p>
           </div>
+
+          {isFromDemo && (
+            <div className="bg-blue-50 border border-blue-100 rounded-xl px-4 py-3 text-sm text-blue-800">
+              <span className="font-semibold">You just tried the demo.</span>{" "}
+              Sign up to upload your own forms — FormPilot reads and autofills them from your saved profile.
+            </div>
+          )}
 
           <form
             action={async () => {

--- a/src/components/forms/DemoNudgeBanner.tsx
+++ b/src/components/forms/DemoNudgeBanner.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+
+function ArrowRightIcon() {
+  return (
+    <svg
+      className="w-4 h-4"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="12 5 19 12 12 19" />
+    </svg>
+  );
+}
+
+export default function DemoNudgeBanner() {
+  const [hasEngaged, setHasEngaged] = useState(false);
+
+  useEffect(() => {
+    function onScroll() {
+      if (window.scrollY > 260) setHasEngaged(true);
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <div className="mb-8 flex flex-col sm:flex-row items-center justify-between gap-4 bg-blue-600 rounded-2xl px-5 py-4 shadow-md">
+      <div>
+        {hasEngaged ? (
+          <>
+            <p className="text-white font-semibold text-sm">
+              Your real profile fills these in automatically.
+            </p>
+            <p className="text-blue-100 text-xs mt-0.5">
+              Create a free account to upload your own forms — FormPilot reads and fills them instantly.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-white font-semibold text-sm">
+              This is a live demo — no account needed.
+            </p>
+            <p className="text-blue-100 text-xs mt-0.5">
+              Sign up to upload your own forms and save your profile for instant autofill.
+            </p>
+          </>
+        )}
+      </div>
+      <Link
+        href="/login?from=demo"
+        className="shrink-0 inline-flex items-center gap-2 px-4 py-2.5 bg-white text-blue-700 text-sm font-semibold rounded-xl hover:bg-blue-50 transition-colors shadow-sm"
+      >
+        {hasEngaged ? "Create free account" : "Sign up free"}
+        <ArrowRightIcon />
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `DemoNudgeBanner` client component upgrades CTA copy after user scrolls 260px into the demo (proxy for engagement with the demo fields)
- All demo page CTAs now point to `/login?from=demo` instead of `/dashboard`
- Login page shows demo-specific subtitle and context banner when `?from=demo` is present

## Test plan
- [ ] Visit `/demo` — see initial nudge banner: "This is a live demo — no account needed"
- [ ] Scroll down past the first field — nudge upgrades to "Your real profile fills these in automatically" + "Create free account" CTA
- [ ] Click any CTA (nudge, nav Get Started, bottom CTA) — lands on `/login?from=demo`
- [ ] On `/login?from=demo` — subtitle reads "Create your account to save and fill your own forms" + blue context banner visible

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)