### PR TITLE
fix(#231): add admin bypass to isProUser — fix Pro quota display

### DIFF
--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -2,8 +2,26 @@ import { prisma } from "@/lib/prisma";
 
 export const FREE_FORM_LIMIT = 5;
 
-/** Returns true if the user has an active Pro subscription */
+const ADMIN_EMAILS = new Set([
+  "wkliwk@gmail.com",
+  ...(process.env.ADMIN_EMAILS?.split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean) ?? []),
+]);
+
+/** Returns true if the user is a hardcoded admin — bypasses all quota and Pro checks */
+async function isAdminUser(userId: string): Promise<boolean> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { email: true },
+  });
+  return !!user?.email && ADMIN_EMAILS.has(user.email.toLowerCase());
+}
+
+/** Returns true if the user has an active Pro subscription (or is an admin) */
 export async function isProUser(userId: string): Promise<boolean> {
+  if (await isAdminUser(userId)) return true;
+
   const sub = await prisma.subscription.findUnique({
     where: { userId },
     select: { status: true, currentPeriodEnd: true },


### PR DESCRIPTION
## Summary
- Adds `ADMIN_EMAILS` set (hardcoded `wkliwk@gmail.com` + optional `ADMIN_EMAILS` env var) to `subscription.ts`
- New `isAdminUser()` helper checked first in `isProUser()` — admin users bypass Stripe entirely and always get Pro treatment
- Fixes dashboard showing "5/5 forms used" + upgrade prompt for the admin account

## Root Cause
Admin bypass was written directly to the working tree but never committed. Every `git checkout` reverted it. This PR permanently commits the fix.

## Test plan
- [ ] Sign in as wkliwk@gmail.com → dashboard shows "Pro" badge + "Unlimited plan — no limits"
- [ ] No "Upgrade to continue" or quota bar shown
- [ ] Free tier user (different account) still sees quota bar correctly

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)