### PR TITLE
fix(#232): export preview shows filled values

### DIFF
--- a/src/components/forms/ExportPreviewModal.tsx
+++ b/src/components/forms/ExportPreviewModal.tsx
@@ -230,12 +230,18 @@ export default function ExportPreviewModal({
         {/* Right: document preview */}
         <div className="hidden lg:flex flex-col flex-1 overflow-hidden bg-white">
           {canPreviewDoc ? (
-            <DocumentImageViewer
-              formId={formId}
-              sourceType={sourceType ?? "PDF"}
-              fields={fields}
-              activeFieldId={activeFieldId}
-            />
+            <>
+              <div className="px-3 py-1.5 bg-slate-50 border-b border-slate-100 text-xs text-slate-400 shrink-0">
+                Preview shows your answers overlaid on the original document
+              </div>
+              <DocumentImageViewer
+                formId={formId}
+                sourceType={sourceType ?? "PDF"}
+                fields={fields}
+                activeFieldId={activeFieldId}
+                liveValues={values}
+              />
+            </>
           ) : (
             <div className="flex-1 flex flex-col items-center justify-center text-slate-400 gap-3 p-8">
               <svg className="w-12 h-12 opacity-30" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
## Summary
- Pass `liveValues={values}` to `DocumentImageViewer` in the export modal — was missing, causing overlays to render empty
- Add clarifying label "Preview shows your answers overlaid on the original document"

## Root Cause
`ExportPreviewModal` had `values` prop (the filled field values) but never passed it as `liveValues` to `DocumentImageViewer`. The overlay renderer skips rendering text/value content when `liveValues` is absent.

## Test plan
- [ ] Open a form with filled fields → click Export
- [ ] Right-side PDF preview shows overlaid field values at their coordinates
- [ ] Label reads "Preview shows your answers overlaid on the original document"
- [ ] Clicking a field in left panel highlights its position in the preview

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)