### PR TITLE
fix: use PDF /TU alt text for fill matching (W-4 and gov forms)

### DIFF
--- a/src/__tests__/fill.test.ts
+++ b/src/__tests__/fill.test.ts
@@ -4,7 +4,7 @@
  * We create in-memory PDFs using pdf-lib directly so tests run without fixtures.
  */
 
-import { PDFDocument } from "pdf-lib";
+import { PDFDocument, PDFName, PDFString } from "pdf-lib";
 import { fillPDF } from "../lib/pdf/fill";
 import type { FormField } from "../lib/ai/analyze-form";
 
@@ -21,6 +21,28 @@ function makeField(overrides: Partial<FormField> & { id: string; label: string }
     commonMistakes: "",
     ...overrides,
   };
+}
+
+/**
+ * Build an in-memory PDF with a text field that has an opaque internal name
+ * but a human-readable tooltip (/TU entry) — like W-4 AcroForm fields.
+ */
+async function buildPDFWithAltTextField(
+  internalName: string,
+  tooltip: string
+): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([600, 800]);
+  const form = doc.getForm();
+
+  const field = form.createTextField(internalName);
+  field.addToPage(page, { x: 50, y: 750, width: 200, height: 20 });
+
+  // Set the /TU (tooltip) entry directly on the AcroField dict
+  field.acroField.dict.set(PDFName.of("TU"), PDFString.of(tooltip));
+
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
 }
 
 /**
@@ -298,6 +320,37 @@ describe("fillPDF — fallback summary page", () => {
     const resultDoc = await PDFDocument.load(filled);
 
     expect(resultDoc.getPageCount()).toBe(1);
+  });
+});
+
+describe("fillPDF — alt text (/TU) matching", () => {
+  it("fills a field via tooltip when internal name is opaque (W-4 style)", async () => {
+    // Simulate a W-4 field: internal name "f1_09[0]", tooltip "First name and middle initial"
+    const buf = await buildPDFWithAltTextField(
+      "f1_09[0]",
+      "First name and middle initial"
+    );
+    const fields: FormField[] = [
+      makeField({ id: "first_name", label: "First name and middle initial", value: "John A" }),
+    ];
+
+    const filled = await fillPDF(buf, fields);
+    const values = await readTextFields(filled);
+
+    expect(values["f1_09[0]"]).toBe("John A");
+  });
+
+  it("falls back to alt text substring match", async () => {
+    // Tooltip "Your Last Name" substring-matches FormField label "Last Name"
+    const buf = await buildPDFWithAltTextField("zz_opaque_99", "Your Last Name");
+    const fields: FormField[] = [
+      makeField({ id: "last_name", label: "Last Name", value: "Doe" }),
+    ];
+
+    const filled = await fillPDF(buf, fields);
+    const values = await readTextFields(filled);
+
+    expect(values["zz_opaque_99"]).toBe("Doe");
   });
 });
 

--- a/src/lib/pdf/fill.ts
+++ b/src/lib/pdf/fill.ts
@@ -5,6 +5,8 @@ import {
   PDFCheckBox,
   PDFRadioGroup,
   PDFDropdown,
+  PDFName,
+  PDFString,
   StandardFonts,
   rgb,
 } from "pdf-lib";
@@ -12,39 +14,65 @@ import type { FormField } from "@/lib/ai/analyze-form";
 import { normalize } from "./annotation-helpers";
 
 /**
+ * Get the tooltip / alternate name (/TU entry) from a PDF AcroForm field.
+ * W-4 and similar government PDFs store the human-readable label here even
+ * when the internal field name is an opaque identifier like "f1_09[0]".
+ */
+function getFieldAltText(pdfField: PDFField): string | undefined {
+  try {
+    const tu = pdfField.acroField.dict.get(PDFName.of("TU"));
+    if (tu instanceof PDFString) return tu.decodeText();
+  } catch {
+    // ignore — not all fields have /TU
+  }
+  return undefined;
+}
+
+/**
  * Resolve which FormField (if any) corresponds to a PDF AcroForm field.
  *
- * Matching priority:
- *  1. Exact normalized match between PDF field name and FormField label
- *  2. Substring match (either direction)
- *  3. Exact normalized match between PDF field name and FormField id
+ * Matching priority (tried against both the PDF field name and its /TU alt text):
+ *  1. Exact normalized match against FormField label
+ *  2. Substring match (either direction) against FormField label
+ *  3. Exact normalized match against FormField id
  *
  * Returns null when no match is found.
  */
-function resolveField(pdfName: string, fields: FormField[]): FormField | null {
-  const normName = normalize(pdfName);
-  if (!normName) return null;
+function resolveField(
+  pdfName: string,
+  altText: string | undefined,
+  fields: FormField[]
+): FormField | null {
+  // Build candidate list: field name first, then alt text (tooltip)
+  const candidates = [pdfName, altText].filter(Boolean) as string[];
 
   // 1. Exact label match
-  const exactLabel = fields.find(
-    (f) => f.value && normalize(f.label) === normName
-  );
-  if (exactLabel) return exactLabel;
+  for (const cand of candidates) {
+    const norm = normalize(cand);
+    if (!norm) continue;
+    const exact = fields.find((f) => f.value && normalize(f.label) === norm);
+    if (exact) return exact;
+  }
 
   // 2. Substring label match (either direction)
-  const subLabel = fields.find(
-    (f) =>
-      f.value &&
-      (normalize(f.label).includes(normName) ||
-        normName.includes(normalize(f.label)))
-  );
-  if (subLabel) return subLabel;
+  for (const cand of candidates) {
+    const norm = normalize(cand);
+    if (!norm) continue;
+    const sub = fields.find(
+      (f) =>
+        f.value &&
+        (normalize(f.label).includes(norm) || norm.includes(normalize(f.label)))
+    );
+    if (sub) return sub;
+  }
 
   // 3. Exact id match (AI snake_case ids occasionally align with PDF names)
-  const exactId = fields.find(
-    (f) => f.value && normalize(f.id) === normName
-  );
-  if (exactId) return exactId;
+  for (const cand of candidates) {
+    const norm = normalize(cand);
+    if (!norm) continue;
+    const exactId = fields.find((f) => f.value && normalize(f.id) === norm);
+    if (exactId) return exactId;
+  }
 
   return null;
 }
@@ -122,18 +150,20 @@ export async function fillPDF(
 
   for (const pdfField of pdfFields) {
     const pdfName = pdfField.getName();
-    const match = resolveField(pdfName, fields);
+    const altText = getFieldAltText(pdfField);
+    const match = resolveField(pdfName, altText, fields);
 
     if (match?.value) {
       const wrote = writeField(pdfField, match.value);
       if (wrote) {
         filled++;
-        console.log(`[fillPDF] matched "${pdfName}" → "${match.label}" = "${match.value}"`);
+        const via = altText && normalize(altText) !== normalize(pdfName) ? ` (via altText: "${altText}")` : "";
+        console.log(`[fillPDF] matched "${pdfName}"${via} → "${match.label}" = "${match.value}"`);
       } else {
         unmatched.push(`${pdfName} (type mismatch for value "${match.value}")`);
       }
     } else {
-      unmatched.push(pdfName);
+      unmatched.push(altText ? `${pdfName} / "${altText}"` : pdfName);
     }
   }
 


### PR DESCRIPTION
## Summary
- Government PDFs (W-4, I-9) use opaque AcroForm field names like `f1_09[0]` that don't match AI-generated labels
- The PDF `/TU` (tooltip) dict entry contains the human-readable label — now we read it
- `resolveField()` now tries both the internal name and alt text for all 3 matching strategies
- Added 2 new tests covering exact and substring alt text matching

## Test plan
- [ ] All 16 existing `fill.test.ts` tests pass
- [ ] New tests confirm `f1_09[0]` with tooltip "First name and middle initial" fills correctly
- [ ] New tests confirm substring fallback via alt text works

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)