### PR TITLE
feat(#200): contextual upgrade nudges — dismissable banner + Pro gate modal

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import DashboardEmptyState from "@/components/forms/DashboardEmptyState";
 import OnboardingChecklist from "@/components/OnboardingChecklist";
 import DashboardStats from "@/components/DashboardStats";
 import QuotaBar from "@/components/QuotaBar";
+import UpgradeNudgeBanner from "@/components/UpgradeNudgeBanner";
+import ProGateModal from "@/components/ProGateModal";
 import { getUserPlan, getOrCreateUsage, FREE_FORM_LIMIT } from "@/lib/subscription";
 
 export default async function DashboardPage() {
@@ -120,6 +122,12 @@ export default async function DashboardPage() {
           isPro={plan === "pro"}
         />
       )}
+      {plan !== "pro" && (
+        <UpgradeNudgeBanner
+          formsUsed={usage.formsThisMonth}
+          limit={FREE_FORM_LIMIT}
+        />
+      )}
       <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8 sm:py-10 space-y-8">
         {/* Stats widget — only shown after first form is used */}
         {allForms.length > 0 && <DashboardStats {...dashboardStats} />}
@@ -137,15 +145,21 @@ export default async function DashboardPage() {
             )}
           </div>
           <div className="flex items-center gap-2">
-            <Link
-              href="/dashboard/batch"
-              className="inline-flex items-center justify-center gap-1.5 px-4 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl text-sm font-semibold hover:bg-slate-50 transition-all shadow-sm active:scale-[0.98]"
+            <ProGateModal
+              feature="Batch Fill"
+              benefit="Upload and auto-fill up to 10 forms at once. Save hours on repetitive paperwork."
+              isPro={plan === "pro"}
             >
-              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="3" y="14" width="7" height="7" /><rect x="14" y="14" width="7" height="7" />
-              </svg>
-              Batch Fill
-            </Link>
+              <Link
+                href="/dashboard/batch"
+                className="inline-flex items-center justify-center gap-1.5 px-4 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl text-sm font-semibold hover:bg-slate-50 transition-all shadow-sm active:scale-[0.98]"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="3" y="14" width="7" height="7" /><rect x="14" y="14" width="7" height="7" />
+                </svg>
+                Batch Fill
+              </Link>
+            </ProGateModal>
             <Link
               href="/dashboard/upload"
               className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-xl text-sm font-semibold hover:bg-blue-700 transition-all shadow-sm active:scale-[0.98]"

--- a/src/components/ProGateModal.tsx
+++ b/src/components/ProGateModal.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+interface Props {
+  feature: string;
+  benefit: string;
+  isPro: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps a Pro-gated UI element. For Pro users, renders children unchanged.
+ * For free users, intercepts clicks and shows an upgrade modal instead.
+ */
+export default function ProGateModal({ feature, benefit, isPro, children }: Props) {
+  const [open, setOpen] = useState(false);
+
+  if (isPro) return <>{children}</>;
+
+  return (
+    <>
+      {/* Click-trap wrapper — intercepts the click before the child navigates */}
+      <div
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        className="cursor-pointer"
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
+        aria-label={`${feature} — Pro feature`}
+      >
+        {children}
+      </div>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Upgrade to access ${feature}`}
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6 flex flex-col gap-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-violet-100 text-violet-700">
+                  Pro
+                </span>
+                <h2 className="text-base font-bold text-slate-900">{feature}</h2>
+              </div>
+              <button
+                onClick={() => setOpen(false)}
+                className="p-1 text-slate-400 hover:text-slate-700 rounded transition-colors"
+                aria-label="Close"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Benefit */}
+            <p className="text-sm text-slate-600">{benefit}</p>
+
+            {/* Price + CTA */}
+            <div className="flex flex-col gap-2 mt-1">
+              <Link
+                href="/dashboard/billing"
+                className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-xl hover:bg-blue-700 transition-colors active:scale-[0.98]"
+                onClick={() => setOpen(false)}
+              >
+                Upgrade to Pro — $9/mo
+              </Link>
+              <button
+                onClick={() => setOpen(false)}
+                className="text-xs text-slate-400 hover:text-slate-600 transition-colors"
+              >
+                Maybe later
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/UpgradeNudgeBanner.tsx
+++ b/src/components/UpgradeNudgeBanner.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+
+const DISMISS_KEY = "upgrade-nudge-dismissed-at";
+const SUPPRESS_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+interface Props {
+  formsUsed: number;
+  limit: number;
+}
+
+export default function UpgradeNudgeBanner({ formsUsed, limit }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const raw = localStorage.getItem(DISMISS_KEY);
+    if (raw) {
+      const dismissedAt = parseInt(raw, 10);
+      if (!isNaN(dismissedAt) && Date.now() - dismissedAt < SUPPRESS_MS) {
+        return; // still suppressed
+      }
+    }
+    setVisible(true);
+  }, []);
+
+  if (!visible || formsUsed < limit - 1) return null;
+
+  const remaining = limit - formsUsed;
+
+  function dismiss() {
+    localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    setVisible(false);
+  }
+
+  return (
+    <div className="bg-amber-50 border-b border-amber-200" role="alert">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-3 flex items-center gap-3">
+        <svg
+          className="w-4 h-4 text-amber-600 shrink-0"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <p className="flex-1 text-sm text-amber-800">
+          You&apos;ve used <strong>{formsUsed} of {limit}</strong> free forms this month.{" "}
+          {remaining === 1 ? "Only 1 form left — " : ""}
+          Upgrade to Pro for unlimited forms.
+        </p>
+        <Link
+          href="/dashboard/billing"
+          className="shrink-0 text-xs font-semibold text-amber-900 bg-amber-100 hover:bg-amber-200 px-3 py-1.5 rounded-lg transition-colors"
+        >
+          Upgrade — $9/mo
+        </Link>
+        <button
+          onClick={dismiss}
+          className="shrink-0 p-1 text-amber-500 hover:text-amber-700 rounded transition-colors"
+          aria-label="Dismiss"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `UpgradeNudgeBanner` — dismissable yellow banner at 4/5 free forms used; localStorage 7-day suppression, hidden for Pro users
- `ProGateModal` — click-intercepting wrapper that shows a feature/benefit/price upgrade modal for free users instead of navigating
- Dashboard wires both: banner below QuotaBar, Batch Fill wrapped in ProGateModal

## What was already done
- Quota-approaching email at 4/5 forms was already triggered from the upload route
- Batch page has its own in-page Pro gate banner

## Test plan
- [ ] Free user with 4/5 forms used: dismissable amber banner appears below QuotaBar
- [ ] Clicking X dismisses banner; refreshing doesn't bring it back (localStorage 7-day)
- [ ] Pro user: no banner shown
- [ ] Free user clicking Batch Fill: upgrade modal appears with feature name, benefit, $9/mo CTA
- [ ] Pro user clicking Batch Fill: navigates to batch page normally
- [ ] "Upgrade to Pro" CTA in modal links to /dashboard/billing

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)