### PR TITLE
feat: inline field validation on blur + scroll-to-error on export (#273)

### DIFF
--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import type { FormField, FieldState } from "@/lib/ai/analyze-form";
 import type { ValidationResult } from "@/lib/validation/validate-form";
 import { validateForm } from "@/lib/validation/validate-form";
+import { validateFieldFormat } from "@/lib/validation/field-rules";
 import { generateSampleValue } from "@/lib/sample-data";
 import { CONFIDENCE_REVIEW_THRESHOLD } from "@/lib/constants";
 import ExportPreviewModal from "./ExportPreviewModal";
@@ -113,6 +114,8 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   const [fieldSuggestions, setFieldSuggestions] = useState<Record<string, { value: string; source: string; sourceType?: "memory" | "history" } | { error: true } | null>>({});
   // correction toasts — fieldId → "pending" | "saving" | "saved" | "dismissed"
   const [correctionToasts, setCorrectionToasts] = useState<Record<string, "pending" | "saving" | "saved" | "dismissed">>({});
+  // blur-based inline validation errors — fieldId → error message string
+  const [blurErrors, setBlurErrors] = useState<Record<string, string>>({});
   // help drawer
   const [helpDrawerFieldId, setHelpDrawerFieldId] = useState<string | null>(null);
   type ExplainResult = { explanation: string; example: string; commonMistakes: string | null; whereToFind: string | null; isPro: boolean; remaining: number };
@@ -187,6 +190,10 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
     setValues(newValues);
     scheduleSave(newValues, fieldStates);
     onValueChange?.(fieldId, value);
+    // Clear blur error as soon as the user starts correcting
+    if (blurErrors[fieldId]) {
+      setBlurErrors((prev) => { const next = { ...prev }; delete next[fieldId]; return next; });
+    }
   }
 
   function handleAccept(fieldId: string) {
@@ -556,6 +563,15 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
     setValidation(result);
 
     if (!result.valid) {
+      // Scroll to and focus the first invalid field so users can fix it in context
+      const firstErrorId = result.errors[0]?.fieldId;
+      if (firstErrorId) {
+        const el = document.getElementById(`field-${firstErrorId}`);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+          el.focus();
+        }
+      }
       setShowForceExportDialog(true);
       return;
     }
@@ -1266,7 +1282,7 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
           const config = tier ? tierConfig[tier] : null;
           const isExplanationExpanded = expandedExplanations.has(field.id);
 
-          const hasError = errorFieldIds.has(field.id);
+          const hasError = errorFieldIds.has(field.id) || Boolean(blurErrors[field.id]);
           const hasWarning = warningFieldIds.has(field.id);
 
           // Card border color
@@ -1431,6 +1447,13 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                             setActiveField(null);
                             onFieldFocus?.(null);
                             handleFieldBlurForCorrection(field.id, field.label);
+                            // Per-field format validation on blur
+                            const formatErr = validateFieldFormat(field, values[field.id] ?? "");
+                            if (formatErr) {
+                              setBlurErrors((prev) => ({ ...prev, [field.id]: formatErr }));
+                            } else {
+                              setBlurErrors((prev) => { const next = { ...prev }; delete next[field.id]; return next; });
+                            }
                           }}
                           disabled={state === "accepted"}
                           aria-disabled={state === "accepted"}
@@ -1454,7 +1477,13 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                         )}
                       </div>
                     )}
-                    {/* Inline validation messages */}
+                    {/* Inline validation messages — blur errors shown in real-time; fieldErrors after export */}
+                    {blurErrors[field.id] && !fieldErrors.some((e) => e.message === blurErrors[field.id]) && (
+                      <p className="mt-1.5 text-xs text-red-600 flex items-center gap-1">
+                        <svg className="w-3 h-3 shrink-0" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clipRule="evenodd" /></svg>
+                        {blurErrors[field.id]}
+                      </p>
+                    )}
                     {fieldErrors.map((err, i) => (
                       <p key={`fe-${i}`} className="mt-1.5 text-xs text-red-600 flex items-center gap-1">
                         <svg className="w-3 h-3 shrink-0" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clipRule="evenodd" /></svg>

--- a/src/components/forms/GuidedFillMode.tsx
+++ b/src/components/forms/GuidedFillMode.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import type { FormField, FieldState } from "@/lib/ai/analyze-form";
+import { validateFieldFormat } from "@/lib/validation/field-rules";
 
 interface Props {
   formId: string;
@@ -97,6 +98,7 @@ export default function GuidedFillMode({
   const [fieldStates, setFieldStates] = useState<Record<string, FieldState>>(initialStates);
   const [autofilling, setAutofilling] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
+  const [blurErrors, setBlurErrors] = useState<Record<string, string>>({});
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const currentGroup = groups[currentStep];
@@ -132,6 +134,9 @@ export default function GuidedFillMode({
     const newValues = { ...values, [fieldId]: value };
     setValues(newValues);
     scheduleSave(newValues, fieldStates);
+    if (blurErrors[fieldId]) {
+      setBlurErrors((prev) => { const next = { ...prev }; delete next[fieldId]; return next; });
+    }
   }
 
   function handleAccept(fieldId: string) {
@@ -426,19 +431,37 @@ export default function GuidedFillMode({
                   </span>
                 </div>
               ) : state !== "rejected" ? (
-                <input
-                  id={`guided-${field.id}`}
-                  type={field.type === "date" ? "date" : "text"}
-                  value={values[field.id] ?? ""}
-                  onChange={(e) => handleValueChange(field.id, e.target.value)}
-                  disabled={state === "accepted"}
-                  className={`w-full px-4 py-3 border rounded-xl text-base md:text-sm min-h-[48px] focus:outline-none focus:ring-2 focus:ring-blue-400 transition-all ${
-                    state === "accepted"
-                      ? "border-emerald-200 bg-emerald-50/60 cursor-not-allowed"
-                      : "border-slate-200 bg-white"
-                  }`}
-                  placeholder={field.example}
-                />
+                <>
+                  <input
+                    id={`guided-${field.id}`}
+                    type={field.type === "date" ? "date" : "text"}
+                    value={values[field.id] ?? ""}
+                    onChange={(e) => handleValueChange(field.id, e.target.value)}
+                    onBlur={() => {
+                      const formatErr = validateFieldFormat(field, values[field.id] ?? "");
+                      if (formatErr) {
+                        setBlurErrors((prev) => ({ ...prev, [field.id]: formatErr }));
+                      } else {
+                        setBlurErrors((prev) => { const next = { ...prev }; delete next[field.id]; return next; });
+                      }
+                    }}
+                    disabled={state === "accepted"}
+                    className={`w-full px-4 py-3 border rounded-xl text-base md:text-sm min-h-[48px] focus:outline-none focus:ring-2 transition-all ${
+                      blurErrors[field.id]
+                        ? "border-red-300 bg-red-50/50 focus:ring-red-400"
+                        : state === "accepted"
+                        ? "border-emerald-200 bg-emerald-50/60 cursor-not-allowed focus:ring-blue-400"
+                        : "border-slate-200 bg-white focus:ring-blue-400"
+                    }`}
+                    placeholder={field.example}
+                  />
+                  {blurErrors[field.id] && (
+                    <p className="mt-1.5 text-xs text-red-600 flex items-center gap-1">
+                      <svg className="w-3 h-3 shrink-0" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clipRule="evenodd" /></svg>
+                      {blurErrors[field.id]}
+                    </p>
+                  )}
+                </>
               ) : (
                 <div className="flex items-center gap-2">
                   <input

--- a/src/lib/validation/field-rules.ts
+++ b/src/lib/validation/field-rules.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-field format validation rules.
+ * Extracted from validate-form.ts so they can be reused for real-time
+ * blur-based validation in the UI without running the full form check.
+ */
+import type { FormField } from "@/lib/ai/analyze-form";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^[\d\s().+\-]{7,20}$/;
+const SSN4_RE = /^\d{4}$/;
+const SSN_FULL_RE = /^\d{3}-?\d{2}-?\d{4}$/;
+const ZIP_RE = /^\d{5}(-\d{4})?$/;
+const DATE_RE = /^(\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4}|\d{1,2}-\d{1,2}-\d{2,4})$/;
+const CURRENCY_RE = /^\$?\d{1,3}(,\d{3})*(\.\d{1,2})?$|^\d+(\.\d{1,2})?$/;
+const EIN_RE = /^\d{2}-?\d{7}$/;
+const ITIN_RE = /^9\d{2}-?\d{2}-?\d{4}$/;
+
+/**
+ * Validate the format of a single field value.
+ * Returns an error message string if invalid, or null if valid.
+ * Empty values are always valid here — required-field checks are done separately.
+ */
+export function validateFieldFormat(field: FormField, value: string): string | null {
+  if (!value.trim()) return null; // empty = valid for format purposes
+
+  const key = field.profileKey?.toLowerCase() ?? "";
+  const label = field.label.toLowerCase();
+
+  if (key === "email" || label.includes("email")) {
+    if (!EMAIL_RE.test(value)) return "Invalid email format. Expected: name@example.com";
+  }
+
+  if (key === "phone" || label.includes("phone") || label.includes("telephone")) {
+    if (!PHONE_RE.test(value)) return "Invalid phone format. Expected: (555) 123-4567 or similar";
+  }
+
+  if (key === "ssn" || label.includes("social security") || label.includes("ssn")) {
+    if (!SSN4_RE.test(value) && !SSN_FULL_RE.test(value)) {
+      return "Invalid SSN format. Expected: last 4 digits (1234) or full (123-45-6789)";
+    }
+  }
+
+  if (label.includes("ein") || label.includes("employer identification")) {
+    if (!EIN_RE.test(value)) return "Invalid EIN format. Expected: 12-3456789";
+  }
+
+  if (label.includes("itin") || label.includes("taxpayer identification")) {
+    if (!ITIN_RE.test(value)) return "Invalid ITIN format. Expected: 9XX-XX-XXXX (starts with 9)";
+  }
+
+  const isCombinedAddressField =
+    (label.includes("city") || label.includes("town") || label.includes("state")) &&
+    label.includes("zip");
+  if (
+    !isCombinedAddressField &&
+    (key === "address.zip" || label.includes("zip") || label.includes("postal code"))
+  ) {
+    if (!ZIP_RE.test(value)) return "Invalid ZIP code. Expected: 12345 or 12345-6789";
+  }
+
+  if (field.type === "date" || key === "dateofbirth" || label.includes("date")) {
+    if (!DATE_RE.test(value)) return "Invalid date format. Expected: MM/DD/YYYY or YYYY-MM-DD";
+  }
+
+  if (
+    key === "annualincome" ||
+    label.includes("income") ||
+    label.includes("salary") ||
+    label.includes("amount") ||
+    label.includes("rent") ||
+    label.includes("payment") ||
+    label.includes("price") ||
+    label.includes("cost") ||
+    label.includes("fee")
+  ) {
+    if (!CURRENCY_RE.test(value.replace(/\s/g, ""))) {
+      return "Invalid amount format. Expected: 1234.56 or $1,234.56";
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/validation/field-rules.ts` with `validateFieldFormat()` — shared validator for email, phone, SSN, EIN, ZIP, date, currency fields
- `FormViewer`: per-field `blurErrors` state, validates on blur, clears on change; red border via `hasError`; on export with errors, scrolls to and focuses first invalid field
- `GuidedFillMode`: same blur validation on the single-field input, red border + inline error message

## Test plan
- [ ] Fill an email field with an invalid email, blur — red inline error appears
- [ ] Type a correction — error clears immediately
- [ ] Fill a phone field with invalid chars, blur — red error appears
- [ ] Leave a required field blank, click Export — page scrolls to the blank field and focuses it
- [ ] Fix all errors, click Export — proceeds to preview modal as before
- [ ] Guided Fill Mode: blur an invalid email field — red border + error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)