### PR TITLE
feat: Product Hunt launch kit (#283)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,8 +47,12 @@ SESSION_EXPIRY_DAYS="30"
 # Pro plan price displayed on landing page pricing section
 NEXT_PUBLIC_PRO_PRICE="$9/mo"
 
+# Product Hunt — set to your PH post URL once live
+# NEXT_PUBLIC_PH_URL=""
+
 # Feature flags
-SHOW_TESTIMONIALS="false"
+# Testimonials shown by default; set to "false" to hide
+# SHOW_TESTIMONIALS="false"
 # Set to "true" in local dev to allow email sends (requires RESEND_API_KEY)
 SEND_EMAILS="false"
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
 import Link from "next/link";
 
-// Set to Product Hunt launch URL once live, e.g.:
-// "https://www.producthunt.com/posts/formpilot"
-const PRODUCT_HUNT_URL: string | null = null;
+// Set NEXT_PUBLIC_PH_URL in env once the Product Hunt post is live
+const PRODUCT_HUNT_URL: string | null = process.env.NEXT_PUBLIC_PH_URL ?? null;
 
-// Toggle testimonials on/off without a deploy — set SHOW_TESTIMONIALS=true in env
-const SHOW_TESTIMONIALS = process.env.SHOW_TESTIMONIALS === "true";
+// Testimonials shown by default; set SHOW_TESTIMONIALS=false to hide
+const SHOW_TESTIMONIALS = process.env.SHOW_TESTIMONIALS !== "false";
 
 const PRO_PRICE = process.env.NEXT_PUBLIC_PRO_PRICE ?? "$9/mo";
 


### PR DESCRIPTION
## Summary
- Testimonials now render by default (no env var needed); set `SHOW_TESTIMONIALS=false` to hide
- `PRODUCT_HUNT_URL` now reads from `NEXT_PUBLIC_PH_URL` env var — set it in Vercel once the PH post is live
- `.env.example` documents `NEXT_PUBLIC_PH_URL` and updates the `SHOW_TESTIMONIALS` comment
- OG image (`public/og-image.png`) and `layout.tsx` metadata were already correct — no changes needed

## Test plan
- [ ] Landing page shows testimonials section without any env var set
- [ ] Setting `NEXT_PUBLIC_PH_URL` in Vercel makes the PH badge appear in hero and footer
- [ ] Social preview for `https://getformpilot.com` shows the OG image correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)