### PR TITLE
feat: annual pricing plan — $79/yr with best value badge (#282)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,8 @@ STRIPE_SECRET_KEY=""
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=""
 # Price ID for the $9/month Pro plan (from Stripe Dashboard → Products)
 STRIPE_PRO_PRICE_ID=""
+# Price ID for the $79/year Pro plan (from Stripe Dashboard → Products → add annual price)
+STRIPE_ANNUAL_PRICE_ID=""
 # Webhook secret from Stripe Dashboard → Webhooks → your endpoint
 STRIPE_WEBHOOK_SECRET=""
 

--- a/src/app/api/billing/create-checkout/route.ts
+++ b/src/app/api/billing/create-checkout/route.ts
@@ -1,13 +1,19 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { getStripe } from "@/lib/stripe";
 import { prisma } from "@/lib/prisma";
 
-export async function POST() {
+export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const plan = req.nextUrl.searchParams.get("plan") === "annual" ? "annual" : "monthly";
+  const priceId =
+    plan === "annual"
+      ? (process.env.STRIPE_ANNUAL_PRICE_ID ?? process.env.STRIPE_PRO_PRICE_ID!)
+      : process.env.STRIPE_PRO_PRICE_ID!;
 
   const stripe = getStripe();
   const userId = session.user.id;
@@ -35,12 +41,7 @@ export async function POST() {
   const checkoutSession = await stripe.checkout.sessions.create({
     customer: customerId,
     mode: "subscription",
-    line_items: [
-      {
-        price: process.env.STRIPE_PRO_PRICE_ID!,
-        quantity: 1,
-      },
-    ],
+    line_items: [{ price: priceId, quantity: 1 }],
     success_url: `${appUrl}/dashboard/billing?success=1`,
     cancel_url: `${appUrl}/dashboard/billing?canceled=1`,
     metadata: { userId },

--- a/src/app/dashboard/billing/page.tsx
+++ b/src/app/dashboard/billing/page.tsx
@@ -10,10 +10,13 @@ interface BillingInfo {
   periodStart: string;
 }
 
+type PlanChoice = "monthly" | "annual";
+
 export default function BillingPage() {
   const [billing, setBilling] = useState<BillingInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
+  const [selectedPlan, setSelectedPlan] = useState<PlanChoice>("annual");
 
   useEffect(() => {
     fetch("/api/billing")
@@ -22,9 +25,9 @@ export default function BillingPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  async function handleUpgrade() {
+  async function handleUpgrade(plan: PlanChoice = selectedPlan) {
     setActionLoading(true);
-    const res = await fetch("/api/billing/create-checkout", { method: "POST" });
+    const res = await fetch(`/api/billing/create-checkout?plan=${plan}`, { method: "POST" });
     const data = await res.json();
     if (data.url) window.location.href = data.url;
     setActionLoading(false);
@@ -68,7 +71,7 @@ export default function BillingPage() {
           </div>
         ) : billing ? (
           <div className="space-y-6">
-            {/* Plan card */}
+            {/* Current plan card */}
             <div className="bg-white rounded-2xl border border-slate-200 p-6 flex items-center justify-between">
               <div>
                 <div className="text-xs font-medium text-slate-400 uppercase tracking-wide mb-1">
@@ -93,11 +96,11 @@ export default function BillingPage() {
               <div>
                 {billing.plan === "free" ? (
                   <button
-                    onClick={handleUpgrade}
+                    onClick={() => handleUpgrade()}
                     disabled={actionLoading}
                     className="bg-blue-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50"
                   >
-                    {actionLoading ? "Redirecting…" : "Upgrade to Pro — $9/mo"}
+                    {actionLoading ? "Redirecting…" : "Upgrade to Pro"}
                   </button>
                 ) : (
                   <button
@@ -110,6 +113,61 @@ export default function BillingPage() {
                 )}
               </div>
             </div>
+
+            {/* Plan picker (free users only) */}
+            {billing.plan === "free" && (
+              <div className="space-y-3">
+                <h2 className="text-sm font-semibold text-slate-700">Choose your plan</h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {/* Monthly */}
+                  <button
+                    type="button"
+                    onClick={() => setSelectedPlan("monthly")}
+                    className={`relative text-left rounded-2xl border-2 p-5 transition-all ${
+                      selectedPlan === "monthly"
+                        ? "border-blue-500 bg-blue-50"
+                        : "border-slate-200 bg-white hover:border-slate-300"
+                    }`}
+                  >
+                    <div className="text-sm font-semibold text-slate-700 mb-1">Monthly</div>
+                    <div className="text-2xl font-bold text-slate-900">$9<span className="text-sm font-normal text-slate-500">/mo</span></div>
+                    <div className="text-xs text-slate-400 mt-1">Billed monthly · cancel anytime</div>
+                    {selectedPlan === "monthly" && (
+                      <div className="absolute top-3 right-3 w-5 h-5 bg-blue-500 rounded-full flex items-center justify-center">
+                        <svg className="w-3 h-3 text-white" viewBox="0 0 20 20" fill="currentColor">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      </div>
+                    )}
+                  </button>
+
+                  {/* Annual */}
+                  <button
+                    type="button"
+                    onClick={() => setSelectedPlan("annual")}
+                    className={`relative text-left rounded-2xl border-2 p-5 transition-all ${
+                      selectedPlan === "annual"
+                        ? "border-blue-500 bg-blue-50"
+                        : "border-slate-200 bg-white hover:border-slate-300"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-sm font-semibold text-slate-700">Annual</span>
+                      <span className="text-xs font-semibold text-emerald-700 bg-emerald-100 px-2 py-0.5 rounded-full">Best value — save 27%</span>
+                    </div>
+                    <div className="text-2xl font-bold text-slate-900">$79<span className="text-sm font-normal text-slate-500">/yr</span></div>
+                    <div className="text-xs text-slate-400 mt-1">$6.58/mo · billed annually</div>
+                    {selectedPlan === "annual" && (
+                      <div className="absolute top-3 right-3 w-5 h-5 bg-blue-500 rounded-full flex items-center justify-center">
+                        <svg className="w-3 h-3 text-white" viewBox="0 0 20 20" fill="currentColor">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      </div>
+                    )}
+                  </button>
+                </div>
+              </div>
+            )}
 
             {/* Usage meter (free only) */}
             {billing.plan === "free" && billing.formsLimit && (
@@ -138,7 +196,7 @@ export default function BillingPage() {
                   <p className="text-sm text-red-600">
                     You&apos;ve reached your free limit.{" "}
                     <button
-                      onClick={handleUpgrade}
+                      onClick={() => handleUpgrade()}
                       className="underline font-medium"
                     >
                       Upgrade to Pro
@@ -171,11 +229,15 @@ export default function BillingPage() {
                   ))}
                 </ul>
                 <button
-                  onClick={handleUpgrade}
+                  onClick={() => handleUpgrade()}
                   disabled={actionLoading}
                   className="mt-4 w-full bg-blue-600 text-white text-sm font-medium py-2.5 rounded-lg hover:bg-blue-700 disabled:opacity-50"
                 >
-                  {actionLoading ? "Redirecting…" : "Get Pro — $9/month"}
+                  {actionLoading
+                    ? "Redirecting…"
+                    : selectedPlan === "annual"
+                    ? "Get Pro — $79/year"
+                    : "Get Pro — $9/month"}
                 </button>
               </div>
             )}

--- a/src/components/ProGateModal.tsx
+++ b/src/components/ProGateModal.tsx
@@ -84,7 +84,7 @@ export default function ProGateModal({ feature, benefit, isPro, children }: Prop
                 className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-xl hover:bg-blue-700 transition-colors active:scale-[0.98]"
                 onClick={() => setOpen(false)}
               >
-                Upgrade to Pro — $9/mo
+                Upgrade to Pro — from $6.58/mo
               </Link>
               <button
                 onClick={() => setOpen(false)}

--- a/src/components/UpgradeNudgeBanner.tsx
+++ b/src/components/UpgradeNudgeBanner.tsx
@@ -60,7 +60,7 @@ export default function UpgradeNudgeBanner({ formsUsed, limit }: Props) {
           href="/dashboard/billing"
           className="shrink-0 text-xs font-semibold text-amber-900 bg-amber-100 hover:bg-amber-200 px-3 py-1.5 rounded-lg transition-colors"
         >
-          Upgrade — $9/mo
+          Upgrade — from $6.58/mo
         </Link>
         <button
           onClick={dismiss}


### PR DESCRIPTION
## Summary
- `create-checkout` API accepts `?plan=annual`, routes to `STRIPE_ANNUAL_PRICE_ID`
- Billing page: two plan cards side by side — Monthly ($9/mo) and Annual ($79/yr, default selected)
- Annual card has "Best value — save 27%" badge and $6.58/mo breakdown
- Pro features CTA button label updates dynamically based on selected plan
- ProGateModal and UpgradeNudgeBanner copy updated to "from $6.58/mo"
- `.env.example` adds `STRIPE_ANNUAL_PRICE_ID`

## Test plan
- [ ] Billing page (free user) shows two plan cards, annual pre-selected
- [ ] Selecting monthly and clicking upgrade → Stripe checkout with monthly price
- [ ] Selecting annual and clicking upgrade → Stripe checkout with annual price
- [ ] Existing monthly subscribers unaffected (no changes to subscription status logic)
- [ ] ProGateModal shows "from $6.58/mo"
- [ ] UpgradeNudgeBanner shows "from $6.58/mo"

> Note: requires `STRIPE_ANNUAL_PRICE_ID` set in Vercel env. Until set, annual checkout falls back to the monthly price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)