### PR TITLE
feat: contextual field Q&A — ask follow-up questions about any form field (#284)

### DIFF
--- a/src/app/api/forms/[id]/fields/[fieldId]/ask/route.ts
+++ b/src/app/api/forms/[id]/fields/[fieldId]/ask/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { callTextAI } from "@/lib/ai/provider-chain";
+import { handleApiError } from "@/lib/api-error";
+import { z } from "zod";
+import type { FormField } from "@/lib/ai/analyze-form";
+
+export const maxDuration = 30;
+
+// Rate limit: 10 questions per form per hour per user (in-memory sliding window)
+const ASK_WINDOW_MS = 60 * 60_000;
+const ASK_LIMIT = 10;
+const askStore = new Map<string, { timestamps: number[] }>();
+
+function checkAskRateLimit(key: string): { allowed: boolean; retryAfter?: number } {
+  const now = Date.now();
+  const cutoff = now - ASK_WINDOW_MS;
+  let entry = askStore.get(key);
+  if (!entry) { entry = { timestamps: [] }; askStore.set(key, entry); }
+  entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+  if (entry.timestamps.length >= ASK_LIMIT) {
+    const retryAfter = Math.ceil((entry.timestamps[0] + ASK_WINDOW_MS - now) / 1000);
+    return { allowed: false, retryAfter: retryAfter > 0 ? retryAfter : 1 };
+  }
+  entry.timestamps.push(now);
+  return { allowed: true };
+}
+
+const bodySchema = z.object({
+  question: z.string().min(1).max(500),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; fieldId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, fieldId } = await params;
+
+  const form = await prisma.form.findUnique({ where: { id } });
+  if (!form || form.userId !== session.user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Per-user per-form rate limit
+  const rlKey = `${session.user.id}:${id}`;
+  const rl = checkAskRateLimit(rlKey);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "rate_limited", retryAfter: rl.retryAfter },
+      { status: 429 }
+    );
+  }
+
+  const body = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const { question } = parsed.data;
+
+  const fields = form.fields as unknown as FormField[];
+  const field = fields.find((f) => f.id === fieldId);
+  if (!field) {
+    return NextResponse.json({ error: "Field not found" }, { status: 404 });
+  }
+
+  const currentValue = field.value ? `The user's current answer for this field is: "${field.value}".` : "";
+
+  const prompt = `You are a form-filling assistant. A user is filling out a form and has a question about a specific field.
+
+Field: "${field.label}"
+Field type: ${field.type}
+${field.explanation ? `Field explanation: ${field.explanation}` : ""}
+${field.example ? `Example answer: ${field.example}` : ""}
+${currentValue}
+
+User's question: ${question}
+
+Answer the question concisely and specifically. Focus on what they need to know to fill in this field correctly. Keep your answer to 2-4 sentences maximum. Do not repeat information already in the explanation unless directly relevant.`;
+
+  try {
+    const answer = await callTextAI(prompt, "field-ask", 512);
+    if (!answer) {
+      return NextResponse.json({ error: "No answer generated" }, { status: 500 });
+    }
+    return NextResponse.json({ answer });
+  } catch (err) {
+    return handleApiError(err, `POST /api/forms/${id}/fields/${fieldId}/ask`);
+  }
+}

--- a/src/components/forms/FieldQA.tsx
+++ b/src/components/forms/FieldQA.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useRef } from "react";
+
+interface Props {
+  formId: string;
+  fieldId: string;
+}
+
+export default function FieldQA({ formId, fieldId }: Props) {
+  const [open, setOpen] = useState(false);
+  const [question, setQuestion] = useState("");
+  const [answer, setAnswer] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function toggleOpen() {
+    setOpen((v) => {
+      if (!v) setTimeout(() => inputRef.current?.focus(), 50);
+      return !v;
+    });
+  }
+
+  async function handleAsk(e: React.FormEvent) {
+    e.preventDefault();
+    if (!question.trim()) return;
+    setLoading(true);
+    setError(null);
+    setAnswer(null);
+    try {
+      const res = await fetch(`/api/forms/${formId}/fields/${fieldId}/ask`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question: question.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        if (res.status === 429) {
+          setError("You've asked 10 questions this hour. Try again later.");
+        } else {
+          setError(data.error ?? "Something went wrong.");
+        }
+        return;
+      }
+      setAnswer(data.answer);
+      setQuestion("");
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mt-3 pt-3 border-t border-slate-100">
+      <button
+        type="button"
+        onClick={toggleOpen}
+        className="flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-800 transition-colors font-medium"
+      >
+        <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" />
+          <path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        {open ? "Hide Q&A" : "Ask about this field"}
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-2">
+          <form onSubmit={handleAsk} className="flex gap-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="e.g. What if I'm self-employed?"
+              maxLength={500}
+              className="flex-1 text-sm px-3 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-blue-400"
+            />
+            <button
+              type="submit"
+              disabled={loading || !question.trim()}
+              className="px-3 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              {loading ? (
+                <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+                  <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
+                </svg>
+              ) : "Ask"}
+            </button>
+          </form>
+
+          {error && (
+            <p className="text-xs text-red-600">{error}</p>
+          )}
+
+          {answer && (
+            <div className="text-sm text-slate-700 bg-blue-50 border border-blue-100 rounded-xl px-4 py-3 space-y-2">
+              <p className="text-xs font-semibold text-blue-600 uppercase tracking-wide">Answer</p>
+              <p className="leading-relaxed">{answer}</p>
+              <button
+                type="button"
+                onClick={() => { setAnswer(null); setTimeout(() => inputRef.current?.focus(), 50); }}
+                className="text-xs text-blue-500 hover:text-blue-700 transition-colors"
+              >
+                Ask another question
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -9,6 +9,7 @@ import { generateSampleValue } from "@/lib/sample-data";
 import { CONFIDENCE_REVIEW_THRESHOLD } from "@/lib/constants";
 import ExportPreviewModal from "./ExportPreviewModal";
 import ConfidenceReviewPanel from "./ConfidenceReviewPanel";
+import FieldQA from "./FieldQA";
 
 interface FormRecord {
   id: string;
@@ -855,6 +856,9 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                         {result.remaining} help lookups remaining this hour.{" "}
                         <a href="/dashboard/billing" className="text-blue-500 hover:text-blue-700 underline">Upgrade for unlimited.</a>
                       </p>
+                    )}
+                    {helpField && (
+                      <FieldQA formId={form.id} fieldId={helpField.id} />
                     )}
                   </div>
                 );


### PR DESCRIPTION
## Summary
- `POST /api/forms/[id]/fields/[fieldId]/ask` — takes a freetext question, calls Claude with field context (label, explanation, example, current user value), rate-limited at 10/hr per form
- `FieldQA` component: collapsible toggle in the field help drawer; answer renders in a blue panel with "Ask another" link
- Mounted in `FormViewer` help drawer after the explanation/example/mistakes section
- Available to all users (free + pro) — retention feature, not Pro-gated

## Test plan
- [ ] Open a form → click "?" on any field → help drawer opens
- [ ] "Ask about this field" toggle appears at the bottom of the explanation
- [ ] Type a question → click Ask → answer appears in blue panel
- [ ] "Ask another question" clears answer and re-focuses input
- [ ] 11th question returns "You've asked 10 questions this hour" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)