### PR TITLE
feat: referral program — refer-a-friend earns bonus form quota

### DIFF
--- a/decisions.jsonl
+++ b/decisions.jsonl
@@ -38,3 +38,8 @@
 {"date":"2026-04-02","project":"FormPilot","decision":"UpgradeNudgeBanner uses localStorage 7-day suppress rather than DB flag","why":"Avoid extra DB column for transient UI state; localStorage is sufficient for cross-session dismiss"}
 {"date":"2026-04-02","project":"FormPilot","decision":"ConfidenceReviewPanel calls handleExport() not doExport() directly","why":"Preserves the normal export path (validation + preview modal). Confidence review is a pre-step, not a bypass."}
 {"date":"2026-04-02","project":"FormPilot","summary":"Fixed missing onClick on IMAGE mobile FieldOverlay (#210) — PDF branch was correct, only IMAGE mobile collapsed branch was affected"}
+{"date":"2026-04-02","project":"FormPilot","summary":"feat(#271): shareable profile import via URL and QR code — signed JWT export, blank-only deep merge import, public import page, QR modal in ProfileForm"}
+{"date":"2026-04-02","project":"FormPilot","summary":"feat(#283): PH launch kit — testimonials on by default, PRODUCT_HUNT_URL from NEXT_PUBLIC_PH_URL env var"}
+{"date":"2026-04-02","project":"FormPilot","summary":"feat(#282): annual pricing plan — $79/yr tier, plan picker UI, from $6.58/mo copy across CTAs"}
+{"date":"2026-04-02","project":"FormPilot","summary":"feat(#284): contextual field Q&A — ask follow-up questions in the help drawer, Claude answers with field context"}
+{"date":"2026-04-02","project":"FormPilot","summary":"feat(#286): proactive re-fill banner — detects same-category prior form within 90 days, offers one-click answer reuse"}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,8 @@ model User {
   image         String?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
+  referralCode  String?   @unique // Short code for referral links (generated on first use)
+  referredBy    String?           // userId of the user who referred this user
 
   accounts     Account[]
   sessions     Session[]
@@ -167,6 +169,7 @@ model UsageCount {
   id               String    @id @default(cuid())
   userId           String    @unique
   formsThisMonth   Int       @default(0)
+  bonusForms       Int       @default(0) // Extra forms earned via referrals (max 5)
   periodStart      DateTime  @default(now())
   quotaNudgeSentAt DateTime? // Set after sending quota-approaching email — suppresses re-sends
   updatedAt        DateTime  @updatedAt

--- a/src/app/api/forms/upload/route.ts
+++ b/src/app/api/forms/upload/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { canUploadForm, incrementFormUsage, isProUser } from "@/lib/subscription";
+import { grantReferralBonus } from "@/lib/referral";
 import { extractTextFromBuffer } from "@/lib/pdf/extract";
 import { analyzeFormFields, analyzeFormFieldsFromImage } from "@/lib/ai/analyze-form";
 import { preprocessImage } from "@/lib/image/preprocess";
@@ -242,6 +243,9 @@ export async function POST(req: NextRequest) {
         }
       }
     }).catch(() => {});
+
+    // Non-blocking referral bonus — grant once when referred user uploads their first form
+    grantReferralBonus(session.user.id).catch(() => {});
 
     // Non-blocking "form is ready" email — skip if no email on session
     if (session.user.email) {

--- a/src/app/api/referral/set/route.ts
+++ b/src/app/api/referral/set/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/** Sets the fp_ref cookie so the referral code survives OAuth redirect. */
+export async function POST(req: NextRequest) {
+  const { ref } = await req.json().catch(() => ({}));
+  const res = NextResponse.json({ ok: true });
+  if (ref && typeof ref === "string" && /^[a-z0-9]{8}$/i.test(ref)) {
+    res.cookies.set("fp_ref", ref, {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+    });
+  }
+  return res;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { cookies } from "next/headers";
 import Link from "next/link";
 import FormCardList from "@/components/forms/FormCardList";
 import DashboardEmptyState from "@/components/forms/DashboardEmptyState";
@@ -9,14 +10,39 @@ import DashboardStats from "@/components/DashboardStats";
 import QuotaBar from "@/components/QuotaBar";
 import UpgradeNudgeBanner from "@/components/UpgradeNudgeBanner";
 import ProGateModal from "@/components/ProGateModal";
+import ReferralCard from "@/components/ReferralCard";
 import { getUserPlan, getOrCreateUsage, FREE_FORM_LIMIT } from "@/lib/subscription";
+import { getUserByReferralCode, getOrCreateReferralCode, getReferralStats } from "@/lib/referral";
 
 export default async function DashboardPage() {
   const session = await auth();
   if (!session?.user) redirect("/login");
 
+  // Apply referral code from cookie if not yet set (best-effort, non-blocking for page render)
+  try {
+    const cookieStore = await cookies();
+    const refCode = cookieStore.get("fp_ref")?.value;
+    if (refCode) {
+      const userRecord = await prisma.user.findUnique({
+        where: { id: session.user.id! },
+        select: { referredBy: true },
+      });
+      if (!userRecord?.referredBy) {
+        const referrerId = await getUserByReferralCode(refCode);
+        if (referrerId && referrerId !== session.user.id) {
+          await prisma.user.update({
+            where: { id: session.user.id! },
+            data: { referredBy: referrerId },
+          });
+        }
+      }
+    }
+  } catch {
+    // Non-blocking — referral tracking failure must not break dashboard
+  }
+
   const PAGE_SIZE = 20;
-  const [forms, allForms, profile, plan, usage] = await Promise.all([
+  const [forms, allForms, profile, plan, usage, referralCode, referralStats] = await Promise.all([
     prisma.form.findMany({
       where: { userId: session.user.id! },
       orderBy: { createdAt: "desc" },
@@ -29,6 +55,8 @@ export default async function DashboardPage() {
     prisma.profile.findUnique({ where: { userId: session.user.id! } }),
     getUserPlan(session.user.id!),
     getOrCreateUsage(session.user.id!),
+    getOrCreateReferralCode(session.user.id!),
+    getReferralStats(session.user.id!),
   ]);
   const hasMore = forms.length > PAGE_SIZE;
   const pagedForms = hasMore ? forms.slice(0, PAGE_SIZE) : forms;
@@ -131,6 +159,15 @@ export default async function DashboardPage() {
       <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8 sm:py-10 space-y-8">
         {/* Stats widget — only shown after first form is used */}
         {allForms.length > 0 && <DashboardStats {...dashboardStats} />}
+
+        {/* Referral card — free users only */}
+        {plan !== "pro" && (
+          <ReferralCard
+            referralCode={referralCode}
+            referralCount={referralStats.count}
+            bonusForms={referralStats.bonusForms}
+          />
+        )}
 
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { Suspense } from "react";
+import ReferralTracker from "@/components/ReferralTracker";
 
 // Set NEXT_PUBLIC_PH_URL in env once the Product Hunt post is live
 const PRODUCT_HUNT_URL: string | null = process.env.NEXT_PUBLIC_PH_URL ?? null;
@@ -161,6 +163,10 @@ export default async function HomePage() {
 
   return (
     <main className="min-h-screen">
+      {/* Invisible referral tracker — sets fp_ref cookie when ?ref=CODE is in the URL */}
+      <Suspense fallback={null}>
+        <ReferralTracker />
+      </Suspense>
       {/* Nav */}
       <nav className="sticky top-0 z-50 bg-white/80 backdrop-blur-lg border-b border-slate-100">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between">

--- a/src/components/ReferralCard.tsx
+++ b/src/components/ReferralCard.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+
+interface ReferralCardProps {
+  referralCode: string;
+  referralCount: number;
+  bonusForms: number;
+}
+
+
+export default function ReferralCard({ referralCode, referralCount, bonusForms }: ReferralCardProps) {
+  const [copied, setCopied] = useState(false);
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://getformpilot.com";
+  const referralUrl = `${appUrl}/?ref=${referralCode}`;
+
+  function handleCopy() {
+    navigator.clipboard.writeText(referralUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-gradient-to-br from-blue-50 to-slate-50 p-5 space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-sm font-semibold text-slate-900">Refer a Friend — Get Free Forms</h2>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Earn +1 extra form per month for each friend who signs up and uploads their first form. Max +5.
+          </p>
+        </div>
+        {bonusForms > 0 && (
+          <span className="shrink-0 inline-flex items-center gap-1 rounded-full bg-blue-100 px-2.5 py-1 text-xs font-semibold text-blue-700">
+            +{bonusForms} bonus {bonusForms === 1 ? "form" : "forms"}
+          </span>
+        )}
+      </div>
+
+      {/* Progress */}
+      {referralCount > 0 && (
+        <p className="text-xs text-slate-600">
+          <span className="font-semibold text-slate-800">{referralCount}</span>{" "}
+          {referralCount === 1 ? "friend" : "friends"} referred so far
+        </p>
+      )}
+
+      {/* Link copy */}
+      <div className="flex items-center gap-2">
+        <div className="flex-1 min-w-0 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600 truncate select-all font-mono">
+          {referralUrl}
+        </div>
+        <button
+          onClick={handleCopy}
+          className="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-xs font-semibold transition-colors active:scale-[0.97]"
+        >
+          {copied ? (
+            <>
+              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+              Copied
+            </>
+          ) : (
+            <>
+              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+              </svg>
+              Copy link
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ReferralTracker.tsx
+++ b/src/components/ReferralTracker.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+
+/**
+ * Invisible component placed on the landing page.
+ * When ?ref=CODE is present, calls /api/referral/set to store the code in a cookie.
+ * The cookie persists through the OAuth flow and is read on first dashboard load.
+ */
+export default function ReferralTracker() {
+  const params = useSearchParams();
+
+  useEffect(() => {
+    const ref = params.get("ref");
+    if (ref && /^[a-z0-9]{8}$/i.test(ref)) {
+      fetch("/api/referral/set", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ref }),
+      }).catch(() => {});
+    }
+  }, [params]);
+
+  return null;
+}

--- a/src/lib/referral.ts
+++ b/src/lib/referral.ts
@@ -1,0 +1,88 @@
+import { prisma } from "@/lib/prisma";
+
+export const REFERRAL_BONUS_PER_REFERRAL = 1;
+export const REFERRAL_MAX_BONUS = 5;
+
+/** Generates a short alphanumeric referral code. */
+function generateCode(): string {
+  const chars = "abcdefghjkmnpqrstuvwxyz23456789"; // no ambiguous chars (0/O, 1/l/I)
+  let code = "";
+  for (let i = 0; i < 8; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+}
+
+/** Returns the user's referral code, creating one if they don't have it yet. */
+export async function getOrCreateReferralCode(userId: string): Promise<string> {
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { referralCode: true } });
+  if (user?.referralCode) return user.referralCode;
+
+  // Generate a unique code — retry on collision (extremely rare)
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const code = generateCode();
+    try {
+      await prisma.user.update({ where: { id: userId }, data: { referralCode: code } });
+      return code;
+    } catch {
+      // Unique constraint violation — try another code
+    }
+  }
+  throw new Error("Failed to generate referral code");
+}
+
+/** Returns the userId for a given referral code, or null if not found. */
+export async function getUserByReferralCode(code: string): Promise<string | null> {
+  const user = await prisma.user.findUnique({ where: { referralCode: code }, select: { id: true } });
+  return user?.id ?? null;
+}
+
+/**
+ * Grants a referral bonus to the referrer when a referred user uploads their first form.
+ * Idempotent: uses the referred user's referredBy field; only grants once (checks existing forms count).
+ */
+export async function grantReferralBonus(referredUserId: string): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { id: referredUserId },
+    select: { referredBy: true },
+  });
+  if (!user?.referredBy) return;
+
+  const referrerId = user.referredBy;
+
+  // Idempotency: only grant if the referred user has exactly 1 form (the one just uploaded)
+  const formCount = await prisma.form.count({ where: { userId: referredUserId } });
+  if (formCount !== 1) return; // already got credit for this referral
+
+  // Apply bonus, capped at REFERRAL_MAX_BONUS
+  await prisma.usageCount.upsert({
+    where: { userId: referrerId },
+    create: { userId: referrerId, formsThisMonth: 0, bonusForms: REFERRAL_BONUS_PER_REFERRAL },
+    update: {
+      bonusForms: { increment: REFERRAL_BONUS_PER_REFERRAL },
+    },
+  });
+
+  // Re-read to enforce cap
+  const usage = await prisma.usageCount.findUnique({ where: { userId: referrerId }, select: { bonusForms: true } });
+  if (usage && usage.bonusForms > REFERRAL_MAX_BONUS) {
+    await prisma.usageCount.update({
+      where: { userId: referrerId },
+      data: { bonusForms: REFERRAL_MAX_BONUS },
+    });
+  }
+}
+
+/** Returns the number of successful referrals for a user (users who signed up and uploaded ≥1 form). */
+export async function getReferralStats(userId: string): Promise<{ count: number; bonusForms: number }> {
+  const [count, usage] = await Promise.all([
+    prisma.user.count({
+      where: {
+        referredBy: userId,
+        forms: { some: {} }, // at least one form uploaded
+      },
+    }),
+    prisma.usageCount.findUnique({ where: { userId }, select: { bonusForms: true } }),
+  ]);
+  return { count, bonusForms: usage?.bonusForms ?? 0 };
+}

--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -47,8 +47,9 @@ export async function canUploadForm(userId: string): Promise<
 
   // getOrCreateUsage lazily resets the counter when a new calendar month starts
   const usage = await getOrCreateUsage(userId);
-  if (usage.formsThisMonth < FREE_FORM_LIMIT) return { allowed: true };
-  return { allowed: false, formsUsed: usage.formsThisMonth, limit: FREE_FORM_LIMIT };
+  const effectiveLimit = FREE_FORM_LIMIT + (usage.bonusForms ?? 0);
+  if (usage.formsThisMonth < effectiveLimit) return { allowed: true };
+  return { allowed: false, formsUsed: usage.formsThisMonth, limit: effectiveLimit };
 }
 
 /** Increments the user's monthly form usage counter */


### PR DESCRIPTION
## Summary
- New schema fields: `User.referralCode`, `User.referredBy`, `UsageCount.bonusForms`
- Referral code generation, bonus granting, cap enforcement in `lib/referral.ts`
- Free users earn +1 form/month per referred user who uploads their first form (max +5)
- Landing page captures `?ref=CODE` via `ReferralTracker` client component → `fp_ref` cookie
- Dashboard applies `referredBy` from cookie on first load; shows `ReferralCard` (free users only)

## Test plan
- [ ] Visit `/?ref=SOMECODE` → check `fp_ref` cookie is set
- [ ] Sign up → confirm `referredBy` is populated on first dashboard load
- [ ] Referrer uploads form → bonus increments, capped at 5
- [ ] ReferralCard visible for free users, hidden for Pro
- [ ] Copy link button copies correct referral URL

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)