### PR TITLE
feat: form completion certificate — Pro-only PDF proof-of-completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ next-env.d.ts
 # prisma
 prisma/*.db
 .claude/
+.serena/

--- a/src/app/api/forms/[id]/certificate/route.ts
+++ b/src/app/api/forms/[id]/certificate/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isProUser } from "@/lib/subscription";
+import { generateCertificate } from "@/lib/pdf/certificate";
+import type { FormField } from "@/lib/ai/analyze-form";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const form = await prisma.form.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      userId: true,
+      title: true,
+      category: true,
+      status: true,
+      fields: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!form || form.userId !== session.user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (form.status !== "COMPLETED") {
+    return NextResponse.json({ error: "Form is not completed" }, { status: 400 });
+  }
+
+  const isPro = await isProUser(session.user.id);
+  if (!isPro) {
+    return NextResponse.json({ error: "Pro plan required" }, { status: 403 });
+  }
+
+  const fields = form.fields as unknown as FormField[];
+
+  const pdfBytes = await generateCertificate({
+    formId: form.id,
+    userId: session.user.id,
+    formTitle: form.title,
+    category: form.category,
+    completedAt: form.updatedAt,
+    fields,
+  });
+
+  const safeTitle = form.title.replace(/[^a-z0-9]/gi, "_");
+
+  return new NextResponse(new Uint8Array(pdfBytes), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename="${safeTitle}_certificate.pdf"`,
+    },
+  });
+}

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -10,6 +10,7 @@ import { CONFIDENCE_REVIEW_THRESHOLD } from "@/lib/constants";
 import ExportPreviewModal, { type ExportFormat } from "./ExportPreviewModal";
 import ConfidenceReviewPanel from "./ConfidenceReviewPanel";
 import FieldQA from "./FieldQA";
+import ProGateModal from "@/components/ProGateModal";
 
 interface FormRecord {
   id: string;
@@ -43,6 +44,54 @@ interface Props {
   onSaveStatusChange?: (status: "idle" | "saving" | "saved" | "error", savedAt: Date | null) => void;
   /** Whether the user has a Pro plan (enables Pro-only export formats). */
   isPro?: boolean;
+}
+
+// -- Certificate download button (Pro-gated) --
+
+function CertificateButton({ formId, isPro }: { formId: string; isPro?: boolean }) {
+  const [downloading, setDownloading] = useState(false);
+
+  async function handleDownload() {
+    if (!isPro) return; // ProGateModal handles the gate
+    setDownloading(true);
+    try {
+      const res = await fetch(`/api/forms/${formId}/certificate`);
+      if (!res.ok) return;
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download =
+        res.headers.get("Content-Disposition")?.split("filename=")[1]?.replace(/"/g, "") ??
+        "certificate.pdf";
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <ProGateModal
+      feature="Completion Certificate"
+      benefit="Download a professional PDF certificate listing all filled fields — perfect for attaching to immigration, HR, or legal submissions."
+      isPro={!!isPro}
+    >
+      <button
+        onClick={handleDownload}
+        disabled={downloading}
+        className="inline-flex items-center gap-1.5 px-4 py-2 border border-emerald-200 text-emerald-700 bg-emerald-50 text-sm rounded-lg font-medium hover:bg-emerald-100 transition-colors disabled:opacity-40 active:scale-[0.98]"
+      >
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <polyline points="9 15 12 18 15 15" />
+          <line x1="12" y1="12" x2="12" y2="18" />
+        </svg>
+        {downloading ? "Downloading..." : "Certificate"}
+      </button>
+    </ProGateModal>
+  );
 }
 
 // -- helpers --
@@ -1042,6 +1091,9 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                 </svg>
                 {exporting ? "Exporting..." : "Export"}
               </button>
+            )}
+            {form.status === "COMPLETED" && (
+              <CertificateButton formId={form.id} isPro={isPro} />
             )}
             {filledCount > 0 && onComplete && (
               <button

--- a/src/lib/pdf/certificate.ts
+++ b/src/lib/pdf/certificate.ts
@@ -1,0 +1,260 @@
+import { PDFDocument, rgb, StandardFonts, PDFPage } from "pdf-lib";
+import { createHash } from "crypto";
+import type { FormField } from "@/lib/ai/analyze-form";
+
+/**
+ * Generates a single-page A4 PDF completion certificate.
+ * Does NOT include field values — only labels and filled status.
+ */
+export async function generateCertificate({
+  formId,
+  userId,
+  formTitle,
+  category,
+  completedAt,
+  fields,
+}: {
+  formId: string;
+  userId: string;
+  formTitle: string;
+  category: string | null;
+  completedAt: Date;
+  fields: FormField[];
+}): Promise<Uint8Array> {
+  const pdfDoc = await PDFDocument.create();
+
+  // A4 dimensions in points (1pt = 1/72 inch)
+  const A4_WIDTH = 595;
+  const A4_HEIGHT = 842;
+
+  const page = pdfDoc.addPage([A4_WIDTH, A4_HEIGHT]);
+
+  const helveticaBold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+  const helvetica = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+  // Colors
+  const blue = rgb(0.145, 0.388, 0.922); // #2563EB
+  const darkGray = rgb(0.118, 0.157, 0.286); // #1E2849
+  const midGray = rgb(0.392, 0.455, 0.545); // #647388
+  const lightGray = rgb(0.886, 0.91, 0.937); // #E2E8EF
+  const white = rgb(1, 1, 1);
+  const green = rgb(0.133, 0.545, 0.498); // #22897F
+  const amber = rgb(0.6, 0.412, 0.086); // #996916
+
+  // -- Header band --
+  page.drawRectangle({ x: 0, y: A4_HEIGHT - 80, width: A4_WIDTH, height: 80, color: blue });
+
+  // WordMark
+  page.drawText("Form", {
+    x: 40,
+    y: A4_HEIGHT - 52,
+    size: 28,
+    font: helveticaBold,
+    color: white,
+  });
+  page.drawText("Pilot", {
+    x: 40 + helveticaBold.widthOfTextAtSize("Form", 28),
+    y: A4_HEIGHT - 52,
+    size: 28,
+    font: helvetica,
+    color: rgb(0.8, 0.88, 1),
+  });
+
+  // "Completion Certificate" label top-right
+  const certLabel = "COMPLETION CERTIFICATE";
+  const certLabelWidth = helveticaBold.widthOfTextAtSize(certLabel, 9);
+  page.drawText(certLabel, {
+    x: A4_WIDTH - 40 - certLabelWidth,
+    y: A4_HEIGHT - 34,
+    size: 9,
+    font: helveticaBold,
+    color: rgb(0.8, 0.88, 1),
+  });
+  const certSubLabel = "Verified by FormPilot";
+  const certSubLabelWidth = helvetica.widthOfTextAtSize(certSubLabel, 8);
+  page.drawText(certSubLabel, {
+    x: A4_WIDTH - 40 - certSubLabelWidth,
+    y: A4_HEIGHT - 50,
+    size: 8,
+    font: helvetica,
+    color: rgb(0.7, 0.8, 0.96),
+  });
+
+  // -- Body --
+  const bodyTop = A4_HEIGHT - 80 - 40; // 40pt padding below header
+
+  // Form title
+  const titleLines = wrapText(formTitle, helveticaBold, 22, A4_WIDTH - 80);
+  let y = bodyTop;
+  for (const line of titleLines) {
+    page.drawText(line, { x: 40, y, size: 22, font: helveticaBold, color: darkGray });
+    y -= 28;
+  }
+
+  y -= 6;
+
+  // Category badge
+  if (category) {
+    const badge = category.replace(/_/g, " ");
+    const badgeWidth = helveticaBold.widthOfTextAtSize(badge, 9) + 16;
+    page.drawRectangle({ x: 40, y: y - 4, width: badgeWidth, height: 20, color: rgb(0.918, 0.957, 1) });
+    page.drawText(badge, { x: 40 + 8, y: y + 2, size: 9, font: helveticaBold, color: blue });
+    y -= 30;
+  }
+
+  y -= 4;
+
+  // Divider
+  page.drawLine({ start: { x: 40, y }, end: { x: A4_WIDTH - 40, y }, thickness: 1, color: lightGray });
+  y -= 24;
+
+  // Completion date + fields count — two columns
+  const completionDateStr = completedAt.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const filledCount = fields.filter((f) => f.value).length;
+  const totalCount = fields.length;
+
+  page.drawText("COMPLETED ON", { x: 40, y, size: 8, font: helveticaBold, color: midGray });
+  page.drawText("FIELDS FILLED", { x: 220, y, size: 8, font: helveticaBold, color: midGray });
+  y -= 18;
+  page.drawText(completionDateStr, { x: 40, y, size: 14, font: helveticaBold, color: darkGray });
+  page.drawText(`${filledCount} / ${totalCount}`, { x: 220, y, size: 14, font: helveticaBold, color: darkGray });
+
+  y -= 36;
+
+  // Divider
+  page.drawLine({ start: { x: 40, y }, end: { x: A4_WIDTH - 40, y }, thickness: 1, color: lightGray });
+  y -= 24;
+
+  // Fields section header
+  page.drawText("FORM FIELDS", { x: 40, y, size: 8, font: helveticaBold, color: midGray });
+  y -= 18;
+
+  // Fields list — two columns, labels only with filled indicator
+  const colWidth = (A4_WIDTH - 80 - 20) / 2;
+  const fieldFontSize = 8.5;
+  const fieldLineHeight = 16;
+
+  const leftFields = fields.filter((_, i) => i % 2 === 0);
+  const rightFields = fields.filter((_, i) => i % 2 === 1);
+  const maxRows = Math.max(leftFields.length, rightFields.length);
+  const maxFieldsToShow = Math.floor((y - 80) / fieldLineHeight); // leave room for footer
+
+  for (let i = 0; i < Math.min(maxRows, maxFieldsToShow); i++) {
+    const left = leftFields[i];
+    const right = rightFields[i];
+
+    if (left) {
+      drawFieldRow(page, 40, y, left, colWidth, fieldFontSize, helvetica, helveticaBold, green, amber, midGray, darkGray);
+    }
+    if (right) {
+      drawFieldRow(page, 40 + colWidth + 20, y, right, colWidth, fieldFontSize, helvetica, helveticaBold, green, amber, midGray, darkGray);
+    }
+    y -= fieldLineHeight;
+  }
+
+  // "… and N more fields" if truncated
+  const shown = Math.min(fields.length, maxFieldsToShow * 2);
+  if (shown < fields.length) {
+    y -= 4;
+    page.drawText(`… and ${fields.length - shown} more fields`, {
+      x: 40, y, size: 8, font: helvetica, color: midGray,
+    });
+  }
+
+  // -- Footer --
+  const certId = buildCertId(formId, userId, completedAt);
+  const footerY = 36;
+
+  page.drawLine({ start: { x: 40, y: footerY + 24 }, end: { x: A4_WIDTH - 40, y: footerY + 24 }, thickness: 1, color: lightGray });
+  page.drawText(`Certificate ID: ${certId}`, {
+    x: 40, y: footerY + 8, size: 8, font: helvetica, color: midGray,
+  });
+  page.drawText("getformpilot.com", {
+    x: A4_WIDTH - 40 - helvetica.widthOfTextAtSize("getformpilot.com", 8),
+    y: footerY + 8,
+    size: 8, font: helvetica, color: midGray,
+  });
+
+  return await pdfDoc.save();
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function drawFieldRow(
+  page: PDFPage,
+  x: number,
+  y: number,
+  field: FormField,
+  maxWidth: number,
+  fontSize: number,
+  regularFont: Awaited<ReturnType<PDFDocument["embedFont"]>>,
+  boldFont: Awaited<ReturnType<PDFDocument["embedFont"]>>,
+  greenColor: ReturnType<typeof rgb>,
+  amberColor: ReturnType<typeof rgb>,
+  midGray: ReturnType<typeof rgb>,
+  darkGray: ReturnType<typeof rgb>
+) {
+  const filled = !!field.value;
+  const dot = filled ? "●" : "○";
+  const dotColor = filled ? greenColor : amberColor;
+
+  // Dot
+  page.drawText(dot, { x, y, size: fontSize - 0.5, font: regularFont, color: dotColor });
+
+  // Label (truncated)
+  const labelX = x + 12;
+  const availWidth = maxWidth - 12;
+  const label = truncateText(field.label, regularFont, fontSize, availWidth);
+  page.drawText(label, {
+    x: labelX, y, size: fontSize, font: field.required ? boldFont : regularFont,
+    color: darkGray,
+  });
+}
+
+function buildCertId(formId: string, userId: string, completedAt: Date): string {
+  return createHash("sha256")
+    .update(`${formId}${userId}${completedAt.toISOString()}`)
+    .digest("hex")
+    .slice(0, 12)
+    .toUpperCase();
+}
+
+function wrapText(
+  text: string,
+  font: Awaited<ReturnType<PDFDocument["embedFont"]>>,
+  size: number,
+  maxWidth: number
+): string[] {
+  const words = text.split(" ");
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+      current = candidate;
+    } else {
+      if (current) lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+function truncateText(
+  text: string,
+  font: Awaited<ReturnType<PDFDocument["embedFont"]>>,
+  size: number,
+  maxWidth: number
+): string {
+  if (font.widthOfTextAtSize(text, size) <= maxWidth) return text;
+  let truncated = text;
+  while (truncated.length > 0 && font.widthOfTextAtSize(truncated + "…", size) > maxWidth) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated + "…";
+}


### PR DESCRIPTION
## Summary
- `lib/pdf/certificate.ts`: A4 PDF via pdf-lib — header, title, category badge, completion date, fields filled count, two-column fields table (label + filled/empty indicator), certificate ID, footer
- `api/forms/[id]/certificate`: GET endpoint — auth, ownership, COMPLETED status, Pro check
- `FormViewer`: `CertificateButton` (ProGateModal-gated) shown when `form.status === COMPLETED`

## Test plan
- [ ] Complete a form → "Certificate" button appears in toolbar
- [ ] Free user: clicking Certificate opens Pro upgrade modal
- [ ] Pro user: certificate downloads as `{title}_certificate.pdf`
- [ ] PDF opens in Preview/Chrome — header blue band, form title, fields table visible
- [ ] Certificate ID is 12 hex chars; completion date formatted as "April 2, 2026"
- [ ] Endpoint returns 400 for non-completed form, 403 for free user, 404 for wrong user

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)