### PR TITLE
feat: harden Chrome extension fill reliability

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -122,40 +122,147 @@ function highlightFields(analysisData) {
   });
 }
 
-// Fill fields with autofill data
-function fillFields(fieldValues) {
-  const selectors = [
-    "input:not([type=hidden]):not([type=submit]):not([type=button]):not([type=reset]):not([type=image])",
-    "textarea",
-    "select",
-  ];
-  const elements = document.querySelectorAll(selectors.join(","));
+/**
+ * Normalize a date value to YYYY-MM-DD for <input type="date"> fields.
+ * Handles MM/DD/YYYY, DD-MM-YYYY, and ISO strings.
+ */
+function normalizeDateValue(value) {
+  if (!value) return value;
+  // Already YYYY-MM-DD
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+  // MM/DD/YYYY
+  const mdy = value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (mdy) return `${mdy[3]}-${mdy[1].padStart(2, "0")}-${mdy[2].padStart(2, "0")}`;
+  // Try generic Date parse as last resort
+  const d = new Date(value);
+  if (!isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+  return value;
+}
 
-  fieldValues.forEach((fv) => {
-    const el = elements[fv.index];
-    if (!el || !fv.value) return;
+/**
+ * Fill a single element with a value.
+ * Returns true if filled, false if skipped (sets skipReason on the field object).
+ */
+function fillElement(el, fv) {
+  if (!fv.value) {
+    fv.skipReason = "no profile match";
+    return false;
+  }
+  if (el.disabled || el.readOnly) {
+    fv.skipReason = "field locked";
+    return false;
+  }
+  // Skip password and payment card fields (security exclusion)
+  if (
+    el.type === "password" ||
+    el.autocomplete === "cc-number" ||
+    el.autocomplete === "cc-csc" ||
+    el.autocomplete === "cc-exp"
+  ) {
+    fv.skipReason = "unsupported field type";
+    return false;
+  }
 
-    // Set value and dispatch events so frameworks pick it up
-    const nativeInputValueSetter =
-      Object.getOwnPropertyDescriptor(
-        el.tagName === "TEXTAREA"
-          ? window.HTMLTextAreaElement.prototype
-          : window.HTMLInputElement.prototype,
-        "value"
-      )?.set;
-
-    if (nativeInputValueSetter) {
-      nativeInputValueSetter.call(el, fv.value);
+  if (el.tagName === "SELECT") {
+    // React-controlled selects require the native HTMLSelectElement setter
+    const nativeSetter = Object.getOwnPropertyDescriptor(
+      HTMLSelectElement.prototype,
+      "value"
+    )?.set;
+    if (nativeSetter) {
+      nativeSetter.call(el, fv.value);
     } else {
       el.value = fv.value;
     }
-
     el.dispatchEvent(new Event("input", { bubbles: true }));
     el.dispatchEvent(new Event("change", { bubbles: true }));
+  } else if (el.type === "date") {
+    const normalized = normalizeDateValue(fv.value);
+    const nativeSetter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value"
+    )?.set;
+    if (nativeSetter) {
+      nativeSetter.call(el, normalized);
+    } else {
+      el.value = normalized;
+    }
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  } else {
+    const proto =
+      el.tagName === "TEXTAREA"
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    const nativeSetter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+    if (nativeSetter) {
+      nativeSetter.call(el, fv.value);
+    } else {
+      el.value = fv.value;
+    }
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  }
 
-    // Visual feedback
-    el.classList.add("formpilot-filled");
-    setTimeout(() => el.classList.remove("formpilot-filled"), 2000);
+  // Visual feedback
+  el.classList.add("formpilot-filled");
+  setTimeout(() => el.classList.remove("formpilot-filled"), 2000);
+  return true;
+}
+
+// Fill fields with autofill data — returns a stats object via Promise
+function fillFields(fieldValues) {
+  return new Promise((resolve) => {
+    const selectors = [
+      "input:not([type=hidden]):not([type=submit]):not([type=button]):not([type=reset]):not([type=image])",
+      "textarea",
+      "select",
+    ];
+
+    const elements = document.querySelectorAll(selectors.join(","));
+    let filledCount = 0;
+    const filledIndices = new Set();
+    const skippedFields = [];
+
+    fieldValues.forEach((fv) => {
+      const el = elements[fv.index];
+      if (!el) {
+        skippedFields.push({ label: fv.label || "unknown", reason: "no profile match" });
+        return;
+      }
+      if (fillElement(el, fv)) {
+        filledCount++;
+        filledIndices.add(fv.index);
+      } else {
+        skippedFields.push({ label: fv.label || getFieldLabel(el), reason: fv.skipReason || "no profile match" });
+      }
+    });
+
+    // Post-fill re-scan after 500ms for dynamically revealed fields
+    // TODO: replace with MutationObserver for better reliability
+    setTimeout(() => {
+      const newElements = document.querySelectorAll(selectors.join(","));
+      let updatedAfterReaction = 0;
+
+      fieldValues.forEach((fv) => {
+        if (filledIndices.has(fv.index)) return; // already filled in first pass
+        const el = newElements[fv.index];
+        if (!el || !fv.value) return;
+        // Only fill newly visible elements
+        if (el.offsetParent !== null) {
+          if (fillElement(el, fv)) {
+            updatedAfterReaction++;
+          }
+        }
+      });
+
+      resolve({
+        filled: filledCount,
+        updatedAfterReaction,
+        skipped: skippedFields.length,
+        skippedFields,
+      });
+    }, 500);
   });
 }
 
@@ -180,8 +287,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   if (message.type === "FILL_FIELDS") {
-    fillFields(message.data);
-    sendResponse({ success: true });
+    fillFields(message.data).then((stats) => {
+      sendResponse({ success: true, stats });
+    });
+    return true; // keep channel open for async response
   }
 
   if (message.type === "CLEAR_HIGHLIGHTS") {

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -181,6 +181,30 @@
       font-size: 13px;
     }
 
+    .fill-summary {
+      padding: 10px 16px;
+      margin: 8px 16px 0;
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-radius: 8px;
+      font-size: 13px;
+      color: #166534;
+    }
+
+    .fill-summary-line {
+      font-weight: 500;
+    }
+
+    .fill-skipped-list {
+      margin: 6px 0 0 16px;
+      color: #64748b;
+      font-size: 12px;
+    }
+
+    .fill-skipped-list li {
+      margin-top: 2px;
+    }
+
     .login-prompt {
       text-align: center;
       padding: 40px 16px;

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -134,15 +134,56 @@ autofillBtn.addEventListener("click", () => {
     return;
   }
 
+  autofillBtn.disabled = true;
+  autofillBtn.textContent = "Filling...";
+
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (tabs[0]) {
-      chrome.tabs.sendMessage(tabs[0].id, {
-        type: "FILL_FIELDS",
-        data: fieldsWithValues,
-      });
+    if (!tabs[0]) {
+      autofillBtn.disabled = false;
+      autofillBtn.textContent = "Autofill";
+      return;
     }
+    chrome.tabs.sendMessage(
+      tabs[0].id,
+      { type: "FILL_FIELDS", data: fieldsWithValues },
+      (result) => {
+        autofillBtn.disabled = false;
+        autofillBtn.textContent = "Autofill";
+        if (result?.stats) {
+          showFillSummary(result.stats);
+        }
+      }
+    );
   });
 });
+
+function showFillSummary(stats) {
+  const { filled, updatedAfterReaction, skipped, skippedFields } = stats;
+  const parts = [`${filled} field${filled !== 1 ? "s" : ""} filled`];
+  if (updatedAfterReaction > 0) {
+    parts.push(`${updatedAfterReaction} updated after page reaction`);
+  }
+  if (skipped > 0) {
+    parts.push(`${skipped} skipped`);
+  }
+
+  let detailHtml = "";
+  if (skippedFields && skippedFields.length > 0) {
+    const items = skippedFields
+      .map((f) => `<li><strong>${f.label}</strong>: ${f.reason}</li>`)
+      .join("");
+    detailHtml = `<ul class="fill-skipped-list">${items}</ul>`;
+  }
+
+  const existing = document.getElementById("fill-summary");
+  if (existing) existing.remove();
+
+  const summary = document.createElement("div");
+  summary.id = "fill-summary";
+  summary.className = "fill-summary";
+  summary.innerHTML = `<div class="fill-summary-line">${parts.join(" · ")}</div>${detailHtml}`;
+  fieldList.insertAdjacentElement("beforebegin", summary);
+}
 
 // Clear highlights
 clearBtn.addEventListener("click", () => {
@@ -152,6 +193,8 @@ clearBtn.addEventListener("click", () => {
     }
   });
   fieldList.innerHTML = "";
+  const summary = document.getElementById("fill-summary");
+  if (summary) summary.remove();
   autofillBtn.style.display = "none";
   clearBtn.style.display = "none";
   scanBtn.textContent = "Scan Form Fields";


### PR DESCRIPTION
## Summary
- **Dropdown fix**: uses `HTMLSelectElement.prototype` native setter + `input`+`change` events so React/Vue-controlled selects correctly register the fill
- **Date normalisation**: `<input type="date">` values are converted to `YYYY-MM-DD` (handles MM/DD/YYYY and ISO formats)
- **Post-fill re-scan**: 500ms delay re-scans for newly visible fields (dynamic forms like Greenhouse/Workday that reveal fields after prior fills)
- **Fill summary**: sidepanel displays "X filled · Y updated after page reaction · Z skipped" with per-field skip reasons
- **Security**: explicit exclusion of `password`, `cc-number`, `cc-csc`, `cc-exp` autocomplete fields

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)