### PR TITLE
fix: remove hardcoded JWT fallback secret + fix falsy merge overwrite

### DIFF
--- a/src/app/api/profile/export-token/route.ts
+++ b/src/app/api/profile/export-token/route.ts
@@ -47,7 +47,10 @@ export async function POST() {
     return NextResponse.json({ error: "Your profile is empty. Add some details first." }, { status: 400 });
   }
 
-  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET ?? "dev-secret");
+  if (!process.env.NEXTAUTH_SECRET) {
+    return NextResponse.json({ error: "Server misconfiguration" }, { status: 500 });
+  }
+  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET);
   const token = await new SignJWT({ profile: safePayload })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()

--- a/src/app/api/profile/import-preview/route.ts
+++ b/src/app/api/profile/import-preview/route.ts
@@ -7,7 +7,10 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Missing token" }, { status: 400 });
   }
 
-  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET ?? "dev-secret");
+  if (!process.env.NEXTAUTH_SECRET) {
+    return NextResponse.json({ error: "Server misconfiguration" }, { status: 500 });
+  }
+  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET);
   try {
     const { payload } = await jwtVerify(token, secret, { algorithms: ["HS256"] });
     if (!payload.profile || typeof payload.profile !== "object") {

--- a/src/app/api/profile/import/route.ts
+++ b/src/app/api/profile/import/route.ts
@@ -43,7 +43,10 @@ export async function POST(req: NextRequest) {
   }
 
   const { token } = parsed.data;
-  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET ?? "dev-secret");
+  if (!process.env.NEXTAUTH_SECRET) {
+    return NextResponse.json({ error: "Server misconfiguration" }, { status: 500 });
+  }
+  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET);
 
   let importedProfile: Record<string, unknown>;
   try {
@@ -71,8 +74,9 @@ export async function POST(req: NextRequest) {
         );
       } else {
         // Only import if the field is blank/missing in the target
+        // Use explicit null/undefined check to avoid overwriting valid falsy values (0, false)
         const current = result[key];
-        if (!current || String(current).trim() === "") {
+        if (current === null || current === undefined || String(current).trim() === "") {
           result[key] = val;
         }
       }


### PR DESCRIPTION
## Security Fix (P0 — #295)
All three profile import/export routes fell back to `"dev-secret"` when `NEXTAUTH_SECRET` was unset. Anyone who knows the source code could mint a valid HS256 token and have it accepted. Now all three fail closed with 500 if the env var is missing.

**Files:** `export-token/route.ts`, `import-preview/route.ts`, `import/route.ts`

## Bug Fix (P1 — #296)
`deepMergeOnlyBlanks` used `!current` which treated `0` and `false` as blank, overwriting valid falsy values like `annualIncome: 0`. Fixed to explicit `null/undefined/empty-string` check.

**File:** `import/route.ts:75`

Closes #295
Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)