### PR TITLE
feat: language preference banner and i18n confidence labels

### DIFF
--- a/src/components/forms/FormPageClient.tsx
+++ b/src/components/forms/FormPageClient.tsx
@@ -87,6 +87,43 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, pr
     (form.fields as FormField[]).some((f) => f.value) ? new Date() : null
   );
 
+  // Language prompt banner — shown once to users who haven't set a language preference
+  const LANG_BANNER_DISMISS_KEY = "fp-lang-banner-dismissed";
+  const [langBannerSaving, setLangBannerSaving] = useState(false);
+  const [langBanner, setLangBanner] = useState<"show" | "hidden">(() => {
+    if (preferredLanguage) return "hidden"; // already set
+    if (typeof window !== "undefined" && localStorage.getItem(LANG_BANNER_DISMISS_KEY)) return "hidden";
+    return "show";
+  });
+  const [langBannerPick, setLangBannerPick] = useState<LanguageCode>("en");
+
+  async function handleLangBannerSave() {
+    setLangBannerSaving(true);
+    try {
+      // Fetch current profile data then POST with updated language preference
+      const current = await fetch("/api/profile").then((r) => r.json()).catch(() => ({}));
+      await fetch("/api/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...(current.data ?? {}), preferredLanguage: langBannerPick }),
+      });
+      localStorage.setItem(LANG_BANNER_DISMISS_KEY, "1");
+      setLangBanner("hidden");
+      if (langBannerPick !== activeLanguage) {
+        handleLanguageChange(langBannerPick);
+      }
+    } catch {
+      setLangBanner("hidden");
+    } finally {
+      setLangBannerSaving(false);
+    }
+  }
+
+  function dismissLangBanner() {
+    localStorage.setItem(LANG_BANNER_DISMISS_KEY, "1");
+    setLangBanner("hidden");
+  }
+
   // Re-fill banner state
   const REFILL_DISMISS_KEY = `fp-refill-dismissed-${form.id}`;
   const [reFillBanner, setReFillBanner] = useState<"show" | "loading" | "done" | "hidden">(() => {
@@ -415,6 +452,39 @@ export default function FormPageClient({ form, hasProfile, preferredLanguage, pr
       {shareError && (
         <div className="flex items-center gap-2 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700">
           {shareError}
+        </div>
+      )}
+
+      {/* Language preference prompt — one-time banner for users without a preference set */}
+      {langBanner === "show" && (
+        <div className="flex flex-wrap items-center gap-3 bg-violet-50 border border-violet-200 rounded-xl px-4 py-3">
+          <svg className="w-4 h-4 text-violet-500 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" /><line x1="2" y1="12" x2="22" y2="12" />
+            <path d="M12 2a15.3 15.3 0 010 20M12 2a15.3 15.3 0 000 20" />
+          </svg>
+          <p className="flex-1 text-sm text-violet-800 font-medium">
+            {getUIString("en", "language_banner.prompt")}
+          </p>
+          <select
+            value={langBannerPick}
+            onChange={(e) => setLangBannerPick(e.target.value as LanguageCode)}
+            className="text-sm border border-violet-200 rounded-lg px-2 py-1.5 bg-white text-slate-700 focus:outline-none focus:ring-2 focus:ring-violet-400"
+            aria-label="Select preferred language"
+          >
+            {SUPPORTED_LANGUAGES.map((lang) => (
+              <option key={lang.code} value={lang.code}>{lang.label}</option>
+            ))}
+          </select>
+          <button
+            onClick={handleLangBannerSave}
+            disabled={langBannerSaving}
+            className="shrink-0 text-xs font-semibold text-white bg-violet-600 hover:bg-violet-700 px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50"
+          >
+            Save
+          </button>
+          <button onClick={dismissLangBanner} className="shrink-0 text-xs text-violet-400 hover:text-violet-600 transition-colors">
+            Skip
+          </button>
         </div>
       )}
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -15,6 +15,62 @@ const UI_STRINGS: Record<string, Record<string, string>> = {
     fr: "Document original",
     pt: "Documento original",
   },
+  "confidence.high": {
+    en: "High match",
+    es: "Coincidencia alta",
+    "zh-Hans": "高度匹配",
+    "zh-Hant": "高度匹配",
+    yue: "高度匹配",
+    ko: "높은 일치",
+    vi: "Khớp cao",
+    tl: "Mataas na tugma",
+    ar: "تطابق عالٍ",
+    hi: "उच्च मिलान",
+    fr: "Correspondance élevée",
+    pt: "Alta correspondência",
+  },
+  "confidence.medium": {
+    en: "Medium match",
+    es: "Coincidencia media",
+    "zh-Hans": "中度匹配",
+    "zh-Hant": "中度匹配",
+    yue: "中度匹配",
+    ko: "중간 일치",
+    vi: "Khớp trung bình",
+    tl: "Katamtamang tugma",
+    ar: "تطابق متوسط",
+    hi: "मध्यम मिलान",
+    fr: "Correspondance moyenne",
+    pt: "Média correspondência",
+  },
+  "confidence.low": {
+    en: "Low match",
+    es: "Coincidencia baja",
+    "zh-Hans": "低度匹配",
+    "zh-Hant": "低度匹配",
+    yue: "低度匹配",
+    ko: "낮은 일치",
+    vi: "Khớp thấp",
+    tl: "Mababang tugma",
+    ar: "تطابق منخفض",
+    hi: "निम्न मिलान",
+    fr: "Correspondance faible",
+    pt: "Baixa correspondência",
+  },
+  "language_banner.prompt": {
+    en: "What language do you prefer for field guidance?",
+    es: "¿En qué idioma prefiere ver las explicaciones?",
+    "zh-Hans": "您希望以哪种语言查看字段说明？",
+    "zh-Hant": "您希望以哪種語言查看欄位說明？",
+    yue: "您想用哪種語言睇欄位說明？",
+    ko: "어떤 언어로 안내를 받으시겠습니까?",
+    vi: "Bạn muốn xem hướng dẫn bằng ngôn ngữ nào?",
+    tl: "Anong wika ang gusto mong gamitin para sa gabay?",
+    ar: "ما اللغة التي تفضلها لشرح الحقول؟",
+    hi: "आप किस भाषा में मार्गदर्शन पसंद करते हैं?",
+    fr: "Dans quelle langue souhaitez-vous voir les explications ?",
+    pt: "Em que idioma prefere ver as explicações?",
+  },
 };
 
 /**
@@ -28,5 +84,13 @@ export function getUIString(
   const strings = UI_STRINGS[key];
   if (!strings) return key;
   const lang = language ?? "en";
-  return strings[lang] ?? strings.en ?? key;
+  return strings[lang] ?? strings["en"] ?? key;
+}
+
+/**
+ * Alias for getUIString with argument order matching common i18n conventions.
+ * @example t("confidence.high", "es") // → "Coincidencia alta"
+ */
+export function t(key: string, lang?: string | null): string {
+  return getUIString(lang, key);
 }


### PR DESCRIPTION
## Summary
- `src/lib/i18n.ts` — adds translated strings for `confidence.high/medium/low` and `language_banner.prompt` across all 12 supported languages; adds `t(key, lang)` alias for conventional usage
- `src/components/forms/FormPageClient.tsx` — one-time language preference banner for users without `preferredLanguage` set; dismissable (localStorage), saves to profile, triggers re-explain in the chosen language

The underlying AI layer (`buildLanguageInstruction`, language-aware `buildCacheKey`, re-explain endpoint) was already complete — this delivers the last missing user-facing pieces from issue #202.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)