### PR TITLE
feat: abandoned form re-engagement email with unsubscribe (#303)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,8 +14,9 @@ model User {
   image         String?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
-  referralCode  String?   @unique // Short code for referral links (generated on first use)
-  referredBy    String?           // userId of the user who referred this user
+  referralCode          String?   @unique // Short code for referral links (generated on first use)
+  referredBy            String?           // userId of the user who referred this user
+  reminderEmailsEnabled Boolean   @default(true) // Set false via unsubscribe link to opt out of nudge emails
 
   accounts     Account[]
   sessions     Session[]

--- a/src/app/api/cron/nudge-abandoned/route.ts
+++ b/src/app/api/cron/nudge-abandoned/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createHmac } from "crypto";
+import { SignJWT } from "jose";
 import { prisma } from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import FormAbandonedEmail from "@/emails/FormAbandonedEmail";
@@ -9,14 +10,26 @@ import type { FormField } from "@/lib/ai/analyze-form";
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://getformpilot.com";
 const CRON_SECRET = process.env.CRON_SECRET ?? "";
 
-// 48 hours — forms idle longer than this are eligible for nudge
-const IDLE_MS = 48 * 60 * 60 * 1000;
+// 24 hours — forms idle longer than this are eligible for nudge
+const IDLE_MS = 24 * 60 * 60 * 1000;
 // 7 days — don't nudge more than once per week per form
 const NUDGE_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+// Fields filled / total below this ratio = "abandoned"
+const COMPLETION_THRESHOLD = 0.2;
 
-/** Generate a signed token for the dismiss link. */
+/** Generate a signed token for the per-form dismiss link. */
 function makeDismissToken(formId: string, userId: string): string {
   return createHmac("sha256", CRON_SECRET).update(`${formId}:${userId}`).digest("hex");
+}
+
+/** Generate a long-lived JWT for the user-level unsubscribe link. */
+async function makeUnsubscribeToken(userId: string): Promise<string> {
+  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET ?? CRON_SECRET);
+  return new SignJWT({ userId })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("365d")
+    .sign(secret);
 }
 
 export async function POST(req: NextRequest) {
@@ -34,7 +47,7 @@ export async function POST(req: NextRequest) {
   let skipped = 0;
 
   try {
-    // Find abandoned forms with their users
+    // Find candidate abandoned forms with user and subscription info
     const forms = await prisma.form.findMany({
       where: {
         status: { in: ["FILLING", "ANALYZED"] },
@@ -43,10 +56,19 @@ export async function POST(req: NextRequest) {
           { lastNudgedAt: null },
           { lastNudgedAt: { lte: nudgeCutoff } },
         ],
+        user: {
+          reminderEmailsEnabled: true,
+        },
       },
       include: {
         user: {
-          select: { id: true, email: true, name: true },
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            reminderEmailsEnabled: true,
+            subscription: { select: { status: true } },
+          },
         },
       },
       take: 500, // Safety cap per run
@@ -60,19 +82,36 @@ export async function POST(req: NextRequest) {
       const totalFields = fields.length;
       const filledCount = fields.filter((f) => f.value && String(f.value).trim()).length;
 
-      const token = makeDismissToken(form.id, user.id);
-      const dismissUrl = `${APP_URL}/api/forms/${form.id}/dismiss?token=${token}`;
+      // Skip if completion >= 20% — not actually abandoned
+      if (totalFields > 0 && filledCount / totalFields >= COMPLETION_THRESHOLD) {
+        skipped++;
+        continue;
+      }
+
+      // Skip Pro users who have already completed at least one form — they are retained
+      if (user.subscription?.status === "ACTIVE") {
+        const completedCount = await prisma.form.count({
+          where: { userId: user.id, status: "COMPLETED" },
+        });
+        if (completedCount > 0) { skipped++; continue; }
+      }
+
+      const dismissToken = makeDismissToken(form.id, user.id);
+      const dismissUrl = `${APP_URL}/api/forms/${form.id}/dismiss?token=${dismissToken}`;
+      const unsubscribeToken = await makeUnsubscribeToken(user.id);
+      const unsubscribeUrl = `${APP_URL}/api/email/unsubscribe?token=${unsubscribeToken}`;
 
       try {
         await sendEmail(
           user.email,
-          `Still need help with "${form.title}"?`,
+          `Your "${form.title}" is waiting — pick up where you left off`,
           React.createElement(FormAbandonedEmail, {
             formTitle: form.title,
             formId: form.id,
             filledCount,
             totalFields,
             dismissUrl,
+            unsubscribeUrl,
             appUrl: APP_URL,
           })
         );

--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jwtVerify } from "jose";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get("token");
+  if (!token) {
+    return new NextResponse("<p>Invalid unsubscribe link.</p>", {
+      status: 400,
+      headers: { "Content-Type": "text/html" },
+    });
+  }
+
+  if (!process.env.NEXTAUTH_SECRET) {
+    return new NextResponse("<p>Server misconfiguration.</p>", {
+      status: 500,
+      headers: { "Content-Type": "text/html" },
+    });
+  }
+
+  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET);
+  let userId: string;
+  try {
+    const { payload } = await jwtVerify(token, secret, { algorithms: ["HS256"] });
+    if (!payload.userId || typeof payload.userId !== "string") {
+      throw new Error("missing userId");
+    }
+    userId = payload.userId;
+  } catch {
+    return new NextResponse("<p>This unsubscribe link is invalid or has expired.</p>", {
+      status: 400,
+      headers: { "Content-Type": "text/html" },
+    });
+  }
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { reminderEmailsEnabled: false },
+  });
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://getformpilot.com";
+  return new NextResponse(
+    `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Unsubscribed — FormPilot</title>
+<style>body{font-family:-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f8fafc}
+.card{text-align:center;padding:40px;max-width:400px}
+h1{color:#0f172a;font-size:1.5rem;margin-bottom:.75rem}
+p{color:#475569;margin-bottom:1.5rem}
+a{color:#2563eb;text-decoration:none}</style>
+</head>
+<body><div class="card">
+<h1>You've been unsubscribed</h1>
+<p>You won't receive any more form reminder emails from FormPilot.</p>
+<p><a href="${appUrl}/dashboard">Back to dashboard</a></p>
+</div></body></html>`,
+    { status: 200, headers: { "Content-Type": "text/html" } }
+  );
+}

--- a/src/emails/FormAbandonedEmail.tsx
+++ b/src/emails/FormAbandonedEmail.tsx
@@ -18,6 +18,7 @@ interface Props {
   filledCount: number;
   totalFields: number;
   dismissUrl: string;
+  unsubscribeUrl: string;
   appUrl: string;
 }
 
@@ -27,6 +28,7 @@ export default function FormAbandonedEmail({
   filledCount,
   totalFields,
   dismissUrl,
+  unsubscribeUrl,
   appUrl,
 }: Props) {
   const formUrl = `${appUrl}/dashboard/forms/${formId}`;
@@ -74,8 +76,11 @@ export default function FormAbandonedEmail({
             Not interested in this form anymore?{" "}
             <a href={dismissUrl} style={link}>
               Mark as done
-            </a>{" "}
-            and we&apos;ll stop reminding you.
+            </a>
+            {" · "}
+            <a href={unsubscribeUrl} style={link}>
+              Unsubscribe from all reminders
+            </a>
           </Text>
         </Container>
       </Body>


### PR DESCRIPTION
## Summary
- `User.reminderEmailsEnabled` boolean added to schema (default `true`); pushed to DB
- `nudge-abandoned` cron updated: 24h idle threshold, completion < 20% filter, Pro user exemption, `reminderEmailsEnabled` guard
- New `GET /api/email/unsubscribe?token=` endpoint — verifies JWT, sets `reminderEmailsEnabled = false`, returns HTML confirmation
- `FormAbandonedEmail` footer now includes both "Mark as done" and "Unsubscribe from all reminders" links

**Note:** Issue #303 asked for a new route at `cron/abandoned-forms` but `cron/nudge-abandoned` already existed doing the same job. Updated that route rather than creating a duplicate; `vercel.json` cron schedule unchanged.

## Test plan
- [ ] POST `/api/cron/nudge-abandoned` with valid `Authorization: Bearer` header → `{ sent: N, skipped: M }` response
- [ ] Form with < 20% filled and `updatedAt` > 24h ago → email queued
- [ ] Form with ≥ 20% filled → skipped
- [ ] User with `reminderEmailsEnabled: false` → skipped
- [ ] Pro user with ≥ 1 completed form → skipped
- [ ] Visit `/api/email/unsubscribe?token=<valid-jwt>` → HTML confirmation page, `reminderEmailsEnabled` set to false in DB
- [ ] Visit with invalid/expired token → 400 error page

🤖 Generated with [Claude Code](https://claude.com/claude-code)