### PR TITLE
Add robots.txt for SEO (#321)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://getformpilot.com";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/dashboard/"],
+      },
+    ],
+    sitemap: `${APP_URL}/sitemap.xml`,
+  };
+}


### PR DESCRIPTION
## Summary
- Add robots.txt via Next.js metadata API (`src/app/robots.ts`)
- Allow all crawlers on public pages, disallow /api/ and /dashboard/
- Point to sitemap.xml

Partial fix for #321 (robots.txt portion). SEO landing pages are a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)