### PR TITLE
fix: fallback field highlighting for image-based forms

### DIFF
--- a/src/components/forms/DocumentImageViewer.tsx
+++ b/src/components/forms/DocumentImageViewer.tsx
@@ -81,6 +81,33 @@ export default function DocumentImageViewer({
     return annotCoords[field.id] ?? null;
   }
 
+  /**
+   * For image forms: estimate evenly-spaced coordinates for fields missing them.
+   * This mirrors the backend fallback so older cached analyses still get highlights.
+   */
+  function getCoordsWithEstimate(field: FormField, fieldIndex: number): FieldCoord | null {
+    const existing = getCoords(field);
+    if (existing) return existing;
+    if (sourceType !== "IMAGE") return null;
+
+    const totalFields = fields.length;
+    if (totalFields === 0) return null;
+
+    const TOP_MARGIN = 0.06;
+    const BOTTOM_MARGIN = 0.06;
+    const USABLE = 1 - TOP_MARGIN - BOTTOM_MARGIN;
+    const spacing = totalFields > 1 ? USABLE / totalFields : USABLE;
+    const y = TOP_MARGIN + spacing * fieldIndex + spacing * 0.5 - 0.015;
+
+    return {
+      x: 0.08,
+      y: Math.min(Math.max(y, TOP_MARGIN), 1 - BOTTOM_MARGIN - 0.03),
+      w: 0.84,
+      h: 0.03,
+      page: 1,
+    };
+  }
+
   const activeField = activeFieldId ? fields.find((f) => f.id === activeFieldId) : null;
   const activeCoords = activeField ? getCoords(activeField) : null;
 
@@ -235,18 +262,21 @@ export default function DocumentImageViewer({
                     setRenderedSize({ w: img.clientWidth, h: img.clientHeight });
                   }}
                 />
-                {renderedSize && fields.map((field) => {
-                  const c = getCoords(field);
+                {renderedSize && fields.map((field, fieldIndex) => {
+                  const c = getCoordsWithEstimate(field, fieldIndex);
                   if (!c || c.page !== 1) return null;
                   const isActive = field.id === activeFieldId;
+                  const isEstimated = !getCoords(field);
                   const value = liveValues[field.id];
                   return (
                     <FieldOverlay
                       key={field.id}
                       c={c}
                       isActive={isActive}
+                      isEstimated={isEstimated}
                       value={value}
                       fieldType={field.type}
+                      fieldLabel={isEstimated ? field.label : undefined}
                       onClick={() => onFieldSelect?.(field.id)}
                     />
                   );
@@ -289,18 +319,21 @@ export default function DocumentImageViewer({
                 setRenderedSize({ w: img.clientWidth, h: img.clientHeight });
               }}
             />
-            {renderedSize && fields.map((field) => {
-              const c = getCoords(field);
+            {renderedSize && fields.map((field, fieldIndex) => {
+              const c = getCoordsWithEstimate(field, fieldIndex);
               if (!c || c.page !== 1) return null;
               const isActive = field.id === activeFieldId;
+              const isEstimated = !getCoords(field);
               const value = liveValues[field.id];
               return (
                 <FieldOverlay
                   key={field.id}
                   c={c}
                   isActive={isActive}
+                  isEstimated={isEstimated}
                   value={value}
                   fieldType={field.type}
+                  fieldLabel={isEstimated ? field.label : undefined}
                   onClick={() => onFieldSelect?.(field.id)}
                 />
               );
@@ -312,7 +345,7 @@ export default function DocumentImageViewer({
             <svg className="w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
             </svg>
-            <span><strong>{activeField.label}</strong> — location not found in image</span>
+            <span><strong>{activeField.label}</strong> — approximate location shown (position may not be exact)</span>
           </div>
         )}
       </div>
@@ -549,42 +582,79 @@ export default function DocumentImageViewer({
 function FieldOverlay({
   c,
   isActive,
+  isEstimated = false,
   value,
   fieldType,
+  fieldLabel,
   onClick,
 }: {
   c: FieldCoord;
   isActive: boolean;
+  isEstimated?: boolean;
   value: string | undefined;
   fieldType?: string;
+  fieldLabel?: string;
   onClick?: () => void;
 }) {
   const isCheckbox = fieldType === "checkbox";
   const isChecked = isCheckbox && value === "Checked";
 
+  // Estimated fields use a dashed border to distinguish from precisely located fields
+  const borderStyle = isEstimated
+    ? isActive
+      ? "2px dashed rgba(217, 119, 6, 0.7)"
+      : "1px dashed rgba(148, 163, 184, 0.5)"
+    : isActive
+      ? "2px solid rgba(217, 119, 6, 0.9)"
+      : "none";
+
+  const bgStyle = isEstimated
+    ? isActive
+      ? "rgba(251, 191, 36, 0.12)"
+      : "rgba(148, 163, 184, 0.06)"
+    : isActive
+      ? "rgba(251, 191, 36, 0.18)"
+      : "transparent";
+
   return (
     <button
       type="button"
       className={`absolute overflow-hidden cursor-pointer ${isCheckbox ? "flex items-center justify-center" : "flex items-center"}`}
-      aria-label="Jump to matching form field"
+      aria-label={isEstimated ? `${fieldLabel ?? "Field"} (approximate location)` : "Jump to matching form field"}
       onClick={onClick}
       style={{
         left: `${c.x * 100}%`,
         top: `${c.y * 100}%`,
         width: `${c.w * 100}%`,
         height: `${c.h * 100}%`,
-        border: isActive ? "2px solid rgba(217, 119, 6, 0.9)" : "none",
-        backgroundColor: isActive ? "rgba(251, 191, 36, 0.18)" : "transparent",
+        border: borderStyle,
+        backgroundColor: bgStyle,
         borderRadius: "2px",
-        boxShadow: isActive ? "0 0 0 3px rgba(251, 191, 36, 0.2)" : "none",
+        boxShadow: isActive && !isEstimated ? "0 0 0 3px rgba(251, 191, 36, 0.2)" : isActive && isEstimated ? "0 0 0 2px rgba(251, 191, 36, 0.15)" : "none",
         paddingLeft: "3px",
         paddingRight: "3px",
         transition: "background-color 0.15s, border-color 0.15s",
         zIndex: isActive ? 2 : 1,
-        background: isActive ? "rgba(251, 191, 36, 0.18)" : "transparent",
       }}
     >
-      {isChecked ? (
+      {isEstimated && fieldLabel ? (
+        <span
+          style={{
+            fontSize: "clamp(6px, 1.2cqw, 10px)",
+            color: isActive ? "#92400e" : "#94a3b8",
+            fontFamily: "Arial, sans-serif",
+            fontStyle: "italic",
+            lineHeight: 1,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            width: "100%",
+            display: "block",
+          }}
+        >
+          {fieldLabel}
+        </span>
+      ) : isChecked ? (
         <svg
           viewBox="0 0 20 20"
           fill="none"

--- a/src/lib/ai/__tests__/estimate-coordinates.test.ts
+++ b/src/lib/ai/__tests__/estimate-coordinates.test.ts
@@ -1,0 +1,90 @@
+import { estimateMissingCoordinates, FormField } from "../analyze-form";
+
+function makeField(overrides: Partial<FormField> = {}): FormField {
+  return {
+    id: "field_1",
+    label: "First Name",
+    type: "text",
+    required: true,
+    explanation: "Your legal first name",
+    example: "John",
+    commonMistakes: "Using nickname",
+    ...overrides,
+  };
+}
+
+describe("estimateMissingCoordinates", () => {
+  it("returns fields unchanged when all have coordinates", () => {
+    const fields: FormField[] = [
+      makeField({ id: "f1", coordinates: { x: 0.1, y: 0.1, w: 0.5, h: 0.03, page: 1 } }),
+      makeField({ id: "f2", coordinates: { x: 0.1, y: 0.3, w: 0.5, h: 0.03, page: 1 } }),
+    ];
+    const result = estimateMissingCoordinates(fields);
+    expect(result).toEqual(fields);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(estimateMissingCoordinates([])).toEqual([]);
+  });
+
+  it("assigns coordinates to fields missing them", () => {
+    const fields: FormField[] = [
+      makeField({ id: "f1" }),
+      makeField({ id: "f2" }),
+      makeField({ id: "f3" }),
+    ];
+    const result = estimateMissingCoordinates(fields);
+
+    for (const field of result) {
+      expect(field.coordinates).toBeDefined();
+      expect(field.coordinates!.page).toBe(1);
+      expect(field.coordinates!.x).toBeGreaterThanOrEqual(0);
+      expect(field.coordinates!.x).toBeLessThanOrEqual(1);
+      expect(field.coordinates!.y).toBeGreaterThanOrEqual(0);
+      expect(field.coordinates!.y).toBeLessThanOrEqual(1);
+      expect(field.coordinates!.w).toBeGreaterThan(0);
+      expect(field.coordinates!.h).toBeGreaterThan(0);
+    }
+  });
+
+  it("distributes fields vertically in order", () => {
+    const fields: FormField[] = [
+      makeField({ id: "f1" }),
+      makeField({ id: "f2" }),
+      makeField({ id: "f3" }),
+    ];
+    const result = estimateMissingCoordinates(fields);
+    const y0 = result[0].coordinates!.y;
+    const y1 = result[1].coordinates!.y;
+    const y2 = result[2].coordinates!.y;
+    expect(y1).toBeGreaterThan(y0);
+    expect(y2).toBeGreaterThan(y1);
+  });
+
+  it("preserves existing coordinates and only fills missing ones", () => {
+    const existing = { x: 0.2, y: 0.5, w: 0.6, h: 0.04, page: 1 };
+    const fields: FormField[] = [
+      makeField({ id: "f1" }),
+      makeField({ id: "f2", coordinates: existing }),
+      makeField({ id: "f3" }),
+    ];
+    const result = estimateMissingCoordinates(fields);
+    expect(result[1].coordinates).toEqual(existing);
+    expect(result[0].coordinates).toBeDefined();
+    expect(result[2].coordinates).toBeDefined();
+    expect(result[0].coordinates).not.toEqual(existing);
+  });
+
+  it("keeps estimated y values within page bounds", () => {
+    // Create many fields to test bounds
+    const fields: FormField[] = Array.from({ length: 50 }, (_, i) =>
+      makeField({ id: `f${i}` })
+    );
+    const result = estimateMissingCoordinates(fields);
+    for (const field of result) {
+      const c = field.coordinates!;
+      expect(c.y).toBeGreaterThanOrEqual(0);
+      expect(c.y + c.h).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/src/lib/ai/analyze-form.ts
+++ b/src/lib/ai/analyze-form.ts
@@ -212,11 +212,11 @@ For each field, provide:
 2. A realistic example answer
 3. Common mistakes people make
 4. The profile data key that could auto-fill it (if applicable)
-5. The bounding box of the fillable input area (NOT the label) as fractions of the image dimensions
+5. **MANDATORY**: The bounding box of the fillable input area (NOT the label) as fractions of the image dimensions. Every field MUST include a "coordinates" object. If you cannot determine the exact position, provide your best estimate based on the field's visual location in the image. Do NOT omit coordinates.
 
 Profile keys available: firstName, lastName, email, phone, dateOfBirth, address.street, address.city, address.state, address.zip, address.country, ssn (last 4 only), passportNumber, employerName, jobTitle, annualIncome
 
-IMPORTANT for coordinates: measure the blank input area where the user writes, not the label text.
+CRITICAL — coordinates are required for every field. Measure the blank input area where the user writes, not the label text.
 - x: left edge of input / image width (0.0 to 1.0)
 - y: top edge of input / image height (0.0 to 1.0)
 - w: input width / image width (0.0 to 1.0)
@@ -492,6 +492,46 @@ async function analyzeImageWithGroq(
   return text;
 }
 
+/**
+ * Assign estimated coordinates to fields that are missing them.
+ * Fields are evenly distributed vertically down the page with a standard
+ * input width, simulating a typical top-to-bottom form layout.
+ */
+export function estimateMissingCoordinates(fields: FormField[]): FormField[] {
+  const fieldsWithoutCoords = fields.filter((f) => !f.coordinates);
+  if (fieldsWithoutCoords.length === 0) return fields;
+
+  const totalFields = fields.length;
+  if (totalFields === 0) return fields;
+
+  const INPUT_X = 0.08;
+  const INPUT_W = 0.84;
+  const INPUT_H = 0.03;
+  const TOP_MARGIN = 0.06;
+  const BOTTOM_MARGIN = 0.06;
+  const USABLE_HEIGHT = 1 - TOP_MARGIN - BOTTOM_MARGIN;
+
+  const hasCoords = new Set(fields.filter((f) => f.coordinates).map((f) => f.id));
+  const spacing = totalFields > 1 ? USABLE_HEIGHT / totalFields : USABLE_HEIGHT;
+
+  return fields.map((field, i) => {
+    if (hasCoords.has(field.id)) return field;
+
+    const y = TOP_MARGIN + spacing * i + spacing * 0.5 - INPUT_H / 2;
+
+    return {
+      ...field,
+      coordinates: {
+        x: INPUT_X,
+        y: Math.min(Math.max(y, TOP_MARGIN), 1 - BOTTOM_MARGIN - INPUT_H),
+        w: INPUT_W,
+        h: INPUT_H,
+        page: 1,
+      },
+    };
+  });
+}
+
 export async function analyzeFormFieldsFromImage(
   base64: string,
   mimeType: string,
@@ -517,7 +557,16 @@ export async function analyzeFormFieldsFromImage(
     }
   }
 
-  return parseAndCacheAnalysis(responseText, language);
+  const analysis = await parseAndCacheAnalysis(responseText, language);
+
+  // Fallback: estimate positions for any fields missing coordinates
+  const missingCount = analysis.fields.filter((f) => !f.coordinates).length;
+  if (missingCount > 0) {
+    console.log(`[image-analysis] ${missingCount}/${analysis.fields.length} fields missing coordinates — estimating positions`);
+    analysis.fields = estimateMissingCoordinates(analysis.fields);
+  }
+
+  return analysis;
 }
 
 export interface HistorySuggestion {


### PR DESCRIPTION
## What
Added fallback field highlighting for image-based forms in side-by-side document preview. When AI vision does not return field coordinates, the system now estimates positions by distributing fields evenly down the page. Estimated overlays are visually distinct (dashed border, italic label) from precisely located fields.

## Why
Closes #230

## Acceptance Criteria
- [x] Image forms show field highlighting in side-by-side view (estimated when coordinates missing)
- [x] Fields without coordinates get estimated positions with a clear visual indicator (dashed border + italic label)
- [x] AI prompt strengthened to make coordinates mandatory for image analysis
- [x] Backend fallback fills in missing coordinates after AI response
- [x] Client-side mirror of estimation for cached analyses without coordinates
- [x] Existing PDF highlighting continues to work unchanged (no changes to PDF code paths)

## Test Plan
1. Upload an image-based form (PNG/JPEG) and open the side-by-side view
2. Verify fields are highlighted with dashed borders and italic labels when coordinates are estimated
3. Click an estimated field -- it should navigate to the form field on the right panel
4. Upload a PDF form with AcroForm annotations and verify highlighting works as before (solid borders)
5. Run `npx tsc --noEmit` -- passes clean
6. Run unit tests for `estimateMissingCoordinates` -- 6/6 pass

### Files Changed
- `src/lib/ai/analyze-form.ts` -- stronger prompt + `estimateMissingCoordinates()` fallback
- `src/components/forms/DocumentImageViewer.tsx` -- client-side estimation + dashed overlay styling
- `src/lib/ai/__tests__/estimate-coordinates.test.ts` -- new unit tests