### PR TITLE
feat: inline profile gap prompts — add missing data without leaving the form (#422)

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -98,3 +98,65 @@ export async function POST(req: NextRequest) {
     return handleApiError(err, "POST /api/profile");
   }
 }
+
+// PATCH: update a single top-level profile key without wiping other fields
+// Used by ProfileGapSlideOver — merges one key into existing profile data
+const patchBodySchema = z.object({
+  key: z.string().min(1).max(100),
+  value: z.string().min(0).max(500),
+});
+
+export async function PATCH(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = patchBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid data" }, { status: 400 });
+  }
+
+  const { key, value } = parsed.data;
+
+  // Only allow keys that are in the profile schema (no arbitrary writes)
+  const allowedKeys = new Set(Object.keys(profileSchema.shape));
+  if (!allowedKeys.has(key)) {
+    return NextResponse.json({ error: "Unknown profile key" }, { status: 400 });
+  }
+
+  try {
+    const existing = await prisma.profile.findUnique({ where: { userId: session.user.id } });
+    const currentData = existing ? decryptSensitiveFields(existing.data as Record<string, unknown>) : {};
+
+    // Merge the single key
+    const merged = { ...currentData, [key]: value };
+    const encryptedData = encryptSensitiveFields(merged as Record<string, unknown>);
+
+    await prisma.profile.upsert({
+      where: { userId: session.user.id },
+      create: { userId: session.user.id, data: encryptedData as object },
+      update: { data: encryptedData as object },
+    });
+
+    // Count other forms that have a field mapped to this profileKey but are currently empty
+    const userForms = await prisma.form.findMany({
+      where: { userId: session.user.id },
+      select: { id: true, fields: true },
+    });
+
+    let impactCount = 0;
+    for (const form of userForms) {
+      const formFields = form.fields as Array<{ profileKey?: string; value?: string }>;
+      if (Array.isArray(formFields)) {
+        const hasGap = formFields.some((f) => f.profileKey === key && !f.value);
+        if (hasGap) impactCount++;
+      }
+    }
+
+    return NextResponse.json({ success: true, impactCount });
+  } catch (err) {
+    return handleApiError(err, "PATCH /api/profile");
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,6 +69,21 @@ html {
   }
 }
 
+@keyframes slideInRight {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.animate-slide-in-right {
+  animation: slideInRight 0.25s ease-out forwards;
+}
+
 @keyframes pulse-gentle {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.6; }

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -20,6 +20,7 @@ import FieldMappingEditor, { type MappingRow } from "./FieldMappingEditor";
 import UpgradeGateModal from "@/components/UpgradeGateModal";
 import KeyboardShortcutsHelp from "./KeyboardShortcutsHelp";
 import FormReviewModal, { type ReviewResult } from "./FormReviewModal";
+import ProfileGapSlideOver from "./ProfileGapSlideOver";
 
 interface FormRecord {
   id: string;
@@ -169,6 +170,18 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   const [autofillConflict, setAutofillConflict] = useState(false);
   const [profileGaps, setProfileGaps] = useState<ProfileGap[]>([]);
   const [gapReportVisible, setGapReportVisible] = useState(false);
+  // Per-field profile gap slide-over
+  const [gapSlideOver, setGapSlideOver] = useState<{ fieldId: string; fieldLabel: string; profileKey: string; profileLabel: string } | null>(null);
+  // Set of profileKeys whose gap prompt has been dismissed for this form session
+  const [dismissedGapKeys, setDismissedGapKeys] = useState<Set<string>>(() => {
+    if (typeof window === "undefined") return new Set();
+    const keys = new Set<string>();
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k?.startsWith(`gapDismissed:${form.id}:`)) keys.add(k.slice(`gapDismissed:${form.id}:`.length));
+    }
+    return keys;
+  });
 
   // Live completion score — recomputed whenever values change
   const completionScore = fields.length > 0
@@ -342,6 +355,19 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
       setShowUndoToast(false);
       if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
       preAutofillSnapshot.current = null;
+    }
+    // Dismiss gap prompt permanently when user manually fills a field
+    if (value.trim()) {
+      const fieldDef = fields.find((f) => f.id === fieldId);
+      if (fieldDef?.profileKey) {
+        const pKey = fieldDef.profileKey;
+        if (!dismissedGapKeys.has(pKey)) {
+          if (typeof window !== "undefined") {
+            localStorage.setItem(`gapDismissed:${form.id}:${pKey}`, "1");
+          }
+          setDismissedGapKeys((prev) => new Set([...prev, pKey]));
+        }
+      }
     }
   }
 
@@ -2556,12 +2582,34 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                       )}
                       {/* Skip reason badge — shown for autofill-skipped fields that are still empty */}
                       {skippedInfo && !values[field.id] && (() => {
+                        const isMissingProfile = skippedInfo.reason === "missing_profile_data" && field.profileKey && !dismissedGapKeys.has(field.profileKey);
                         const SKIP_REASON_LABELS: Record<string, string> = {
                           low_confidence: "Not enough info in your profile",
                           missing_profile_data: "Missing from your profile",
                           type_mismatch: "This field needs a specific format",
                           timeout: "Autofill timed out — try again",
                         };
+                        if (isMissingProfile) {
+                          const gap = profileGaps.find((g) => g.profileKey === field.profileKey);
+                          return (
+                            <button
+                              type="button"
+                              onClick={() => setGapSlideOver({
+                                fieldId: field.id,
+                                fieldLabel: field.label,
+                                profileKey: field.profileKey!,
+                                profileLabel: gap?.profileLabel ?? field.profileKey!,
+                              })}
+                              className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 hover:bg-amber-200 transition-colors cursor-pointer"
+                              title="Add this to your profile to autofill"
+                            >
+                              <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                              </svg>
+                              Add to profile →
+                            </button>
+                          );
+                        }
                         return (
                           <span
                             className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700"
@@ -2572,6 +2620,29 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                             </svg>
                             Fill manually
                           </span>
+                        );
+                      })()}
+                      {/* Low-confidence autofill badge — clickable if profileKey is known and not dismissed */}
+                      {!skippedInfo && field.profileKey && !values[field.id] && autofillSummary !== null && !dismissedGapKeys.has(field.profileKey) && (() => {
+                        const gap = profileGaps.find((g) => g.profileKey === field.profileKey);
+                        if (!gap) return null;
+                        return (
+                          <button
+                            type="button"
+                            onClick={() => setGapSlideOver({
+                              fieldId: field.id,
+                              fieldLabel: field.label,
+                              profileKey: field.profileKey!,
+                              profileLabel: gap.profileLabel,
+                            })}
+                            className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 hover:bg-amber-200 transition-colors cursor-pointer"
+                            title="Add this to your profile to autofill"
+                          >
+                            <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                              <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                            </svg>
+                            Add to profile →
+                          </button>
                         );
                       })()}
                       {/* Notepad icon — shown when a note exists for this field */}
@@ -3073,6 +3144,22 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
           </>
         )}
       </div>
+    )}
+    {/* Profile gap slide-over — opens when user clicks "Add to profile →" badge */}
+    {gapSlideOver && (
+      <ProfileGapSlideOver
+        fieldLabel={gapSlideOver.fieldLabel}
+        profileKey={gapSlideOver.profileKey}
+        profileLabel={gapSlideOver.profileLabel}
+        formId={form.id}
+        onSaved={() => {
+          // Dismiss locally and re-run autofill to fill the field with the new data
+          setDismissedGapKeys((prev) => new Set([...prev, gapSlideOver.profileKey]));
+          setGapSlideOver(null);
+          handleAutofill();
+        }}
+        onClose={() => setGapSlideOver(null)}
+      />
     )}
     </>
   );

--- a/src/components/forms/ProfileGapSlideOver.tsx
+++ b/src/components/forms/ProfileGapSlideOver.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+interface Props {
+  fieldLabel: string;       // form field label, e.g. "Phone number"
+  profileKey: string;       // profile key, e.g. "phone"
+  profileLabel: string;     // human label, e.g. "Phone number"
+  formId: string;
+  onSaved: () => void;      // called after profile saved — triggers re-autofill
+  onClose: () => void;
+}
+
+export default function ProfileGapSlideOver({ fieldLabel, profileKey, profileLabel, formId, onSaved, onClose }: Props) {
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [impactCount, setImpactCount] = useState<number | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  async function handleSave() {
+    if (!value.trim()) {
+      setError("Please enter a value");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: profileKey, value: value.trim() }),
+      });
+      const data = await res.json() as { success?: boolean; impactCount?: number; error?: string };
+      if (!res.ok || !data.success) {
+        setError(data.error ?? "Failed to save. Try again.");
+        return;
+      }
+      setImpactCount(data.impactCount ?? 0);
+      // Mark gap as dismissed for this field in localStorage
+      if (typeof window !== "undefined") {
+        localStorage.setItem(`gapDismissed:${formId}:${profileKey}`, "1");
+      }
+      onSaved();
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/30 backdrop-blur-[2px]"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Slide-over panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gap-slideover-title"
+        className="fixed right-0 top-0 h-full z-50 w-full max-w-sm bg-white shadow-2xl flex flex-col animate-slide-in-right"
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 border-b border-slate-100">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 p-1.5 text-slate-400 hover:text-slate-700 rounded-lg transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+
+          <div className="flex items-center gap-2 mb-1 pr-6">
+            <span className="w-7 h-7 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+              <svg className="w-3.5 h-3.5 text-amber-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+            </span>
+            <h2 id="gap-slideover-title" className="text-sm font-bold text-slate-900">
+              Profile data missing
+            </h2>
+          </div>
+          <p className="text-xs text-slate-500 pl-9">
+            <span className="font-medium text-slate-700">{fieldLabel}</span> couldn&apos;t be autofilled — your profile is missing <span className="font-medium text-slate-700">{profileLabel}</span>.
+          </p>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          <div>
+            <label htmlFor="gap-value-input" className="block text-xs font-semibold text-slate-700 mb-1.5">
+              {profileLabel}
+            </label>
+            <input
+              ref={inputRef}
+              id="gap-value-input"
+              type="text"
+              value={value}
+              onChange={(e) => { setValue(e.target.value); setError(null); }}
+              onKeyDown={(e) => { if (e.key === "Enter") handleSave(); }}
+              placeholder={`Enter your ${profileLabel.toLowerCase()}`}
+              className="w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+            />
+            {error && <p className="mt-1.5 text-xs text-red-600">{error}</p>}
+          </div>
+
+          {impactCount !== null && impactCount > 0 && (
+            <div className="flex items-center gap-2 bg-emerald-50 border border-emerald-200 rounded-xl px-3.5 py-2.5">
+              <svg className="w-4 h-4 text-emerald-600 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M22 11.08V12a10 10 0 11-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+              </svg>
+              <p className="text-xs text-emerald-700 font-medium">
+                This will also improve {impactCount} other form{impactCount !== 1 ? "s" : ""} in your library
+              </p>
+            </div>
+          )}
+
+          <div className="bg-slate-50 rounded-xl px-3.5 py-3">
+            <p className="text-xs text-slate-500 leading-relaxed">
+              This value will be saved to your profile and used to autofill similar fields in future forms. You can update it anytime in your profile settings.
+            </p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 pb-6 pt-2 border-t border-slate-100 space-y-2">
+          <button
+            onClick={handleSave}
+            disabled={saving || !value.trim()}
+            className="w-full py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-xl hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
+          >
+            {saving ? "Saving…" : "Save & autofill"}
+          </button>
+          <button
+            onClick={onClose}
+            className="w-full py-2 text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Skip for now
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Fields that autofill couldn't fill due to missing profile data now show a clickable **"Add to profile →"** amber badge instead of a static "Fill manually" label
- Clicking opens a slide-over panel with an input for the specific missing profile key
- On save, profile is patched and autofill re-runs immediately — the field populates without the user leaving the form
- Badge is dismissed permanently per-field when user manually types a value
- "This will also improve N other forms" message shown after saving

## New API
- `PATCH /api/profile` — merges a single profile key without overwriting other fields. Returns `{ success, impactCount }` where `impactCount` = number of other forms with the same unfilled gap.

## New component
- `ProfileGapSlideOver.tsx` — slide-over panel (slides in from right), accepts `profileKey + profileLabel + fieldLabel`, saves via PATCH, calls back `onSaved` to trigger autofill

## Test plan
- [ ] Upload a form, run autofill with an incomplete profile (missing e.g. phone)
- [ ] Field skipped due to "missing_profile_data" shows "Add to profile →" badge
- [ ] Clicking badge opens slide-over with correct profile label
- [ ] Entering value + "Save & autofill" closes slide-over and re-runs autofill
- [ ] Field now populates with the new value
- [ ] "Also improves N other forms" shown when other forms have the same gap
- [ ] Manually typing in the field dismisses the badge permanently
- [ ] Badge doesn't reappear after page reload (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)