### PR TITLE
feat: learn from corrections — profile + memory update on user edits (#423)

### DIFF
--- a/src/app/api/profile/learn/route.ts
+++ b/src/app/api/profile/learn/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { z } from "zod";
+import { normalizeLabel } from "@/lib/ai/suggestion-engine";
+import { encryptSensitiveFields, decryptSensitiveFields } from "@/lib/crypto";
+import { handleApiError } from "@/lib/api-error";
+
+// POST /api/profile/learn — save a user correction to form memory AND profile
+// Called when user edits an autofilled field and chooses "Save this correction"
+//
+// - Always writes to FormMemory (fieldType: "correction", confidence: 1.0)
+// - If profileKey is provided and maps to a known profile field, also patches the profile
+
+const ALLOWED_ADDRESS_SUBKEYS = new Set(["street", "city", "state", "zip", "country"]);
+
+const bodySchema = z.object({
+  fieldLabel: z.string().min(1).max(200),
+  value: z.string().min(1).max(2000),
+  profileKey: z.string().max(100).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid data" }, { status: 400 });
+  }
+
+  const { fieldLabel, value, profileKey } = parsed.data;
+  const normalizedLabel = normalizeLabel(fieldLabel);
+
+  if (!normalizedLabel) {
+    return NextResponse.json({ error: "Invalid field label" }, { status: 400 });
+  }
+
+  try {
+    // 1. Always save to FormMemory
+    await prisma.formMemory.upsert({
+      where: { userId_label: { userId: session.user.id, label: normalizedLabel } },
+      create: {
+        userId: session.user.id,
+        fieldType: "correction",
+        label: normalizedLabel,
+        value,
+        confidence: 1.0,
+        sourceFormId: "manual",
+        sourceTitle: "User correction",
+        lastUsed: new Date(),
+      },
+      update: {
+        value,
+        fieldType: "correction",
+        confidence: 1.0,
+        lastUsed: new Date(),
+      },
+    });
+
+    // 2. Also patch the profile if a valid profileKey was provided
+    let profileUpdated = false;
+    if (profileKey) {
+      const allowedTopKeys = new Set([
+        "firstName", "lastName", "email", "phone", "dateOfBirth",
+        "employerName", "jobTitle", "annualIncome", "ssn", "passportNumber", "driverLicense", "taxId",
+      ]);
+      const isAddressKey = profileKey.startsWith("address.") &&
+        ALLOWED_ADDRESS_SUBKEYS.has(profileKey.slice("address.".length));
+
+      if (allowedTopKeys.has(profileKey) || isAddressKey) {
+        const existing = await prisma.profile.findUnique({ where: { userId: session.user.id } });
+        const currentData = existing ? decryptSensitiveFields(existing.data as Record<string, unknown>) : {};
+
+        let merged: Record<string, unknown>;
+        if (isAddressKey) {
+          const addressField = profileKey.slice("address.".length);
+          const existingAddress = (currentData.address as Record<string, string>) ?? {};
+          merged = { ...currentData, address: { ...existingAddress, [addressField]: value } };
+        } else {
+          merged = { ...currentData, [profileKey]: value };
+        }
+
+        const encryptedData = encryptSensitiveFields(merged as Record<string, unknown>);
+        await prisma.profile.upsert({
+          where: { userId: session.user.id },
+          create: { userId: session.user.id, data: encryptedData as object },
+          update: { data: encryptedData as object },
+        });
+        profileUpdated = true;
+      }
+    }
+
+    return NextResponse.json({ success: true, profileUpdated });
+  } catch (err) {
+    return handleApiError(err, "POST /api/profile/learn");
+  }
+}

--- a/src/components/forms/CorrectionsReviewModal.tsx
+++ b/src/components/forms/CorrectionsReviewModal.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export interface SavedCorrection {
+  fieldId: string;
+  fieldLabel: string;
+  originalValue: string;
+  correctedValue: string;
+  profileUpdated: boolean;
+}
+
+interface Props {
+  corrections: SavedCorrection[];
+  onExport: () => void;
+  onClose: () => void;
+}
+
+export default function CorrectionsReviewModal({ corrections, onExport, onClose }: Props) {
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    btnRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const profileUpdatedCount = corrections.filter((c) => c.profileUpdated).length;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      role="presentation"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="corrections-modal-title"
+        className="relative bg-white rounded-2xl shadow-xl w-full max-w-md flex flex-col gap-4 animate-slide-down overflow-y-auto max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-0">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 p-1 text-slate-400 hover:text-slate-700 rounded transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+
+          <div className="flex items-center gap-2 mb-1 pr-6">
+            <span className="w-7 h-7 rounded-full bg-violet-100 flex items-center justify-center shrink-0">
+              <svg className="w-3.5 h-3.5 text-violet-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19H4v-3L16.5 3.5z"/>
+              </svg>
+            </span>
+            <h2 id="corrections-modal-title" className="text-base font-bold text-slate-900">
+              Your corrections
+            </h2>
+          </div>
+          <p className="text-sm text-slate-500 pl-9">
+            You updated {corrections.length} autofilled field{corrections.length !== 1 ? "s" : ""} in this session.
+            {profileUpdatedCount > 0 && (
+              <span className="text-emerald-700 font-medium"> {profileUpdatedCount} saved to your profile.</span>
+            )}
+          </p>
+        </div>
+
+        {/* Corrections list */}
+        <div className="px-6">
+          <div className="border border-slate-100 rounded-xl divide-y divide-slate-100 overflow-hidden">
+            {corrections.map((c) => (
+              <div key={c.fieldId} className="px-3 py-3 bg-white">
+                <p className="text-xs font-semibold text-slate-500 mb-1">{c.fieldLabel}</p>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-slate-400 line-through truncate max-w-[120px]">{c.originalValue || "—"}</span>
+                  <svg className="w-3 h-3 text-slate-300 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" />
+                  </svg>
+                  <span className="text-xs font-medium text-slate-700 truncate">{c.correctedValue}</span>
+                  {c.profileUpdated && (
+                    <span className="ml-auto shrink-0 text-xs text-emerald-600 font-medium">Profile updated</span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="px-6 pb-6 flex flex-col gap-2">
+          <button
+            ref={btnRef}
+            onClick={onExport}
+            className="w-full py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-xl hover:bg-blue-700 transition-colors active:scale-[0.98]"
+          >
+            Looks good — export
+          </button>
+          <button
+            onClick={onClose}
+            className="w-full py-2 text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Go back and review
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -21,6 +21,7 @@ import UpgradeGateModal from "@/components/UpgradeGateModal";
 import KeyboardShortcutsHelp from "./KeyboardShortcutsHelp";
 import FormReviewModal, { type ReviewResult } from "./FormReviewModal";
 import ProfileGapSlideOver from "./ProfileGapSlideOver";
+import CorrectionsReviewModal, { type SavedCorrection } from "./CorrectionsReviewModal";
 
 interface FormRecord {
   id: string;
@@ -218,6 +219,11 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   const [fieldSuggestions, setFieldSuggestions] = useState<Record<string, { value: string; source: string; sourceType?: "memory" | "history" } | { error: true } | null>>({});
   // correction toasts — fieldId → "pending" | "saving" | "saved" | "dismissed"
   const [correctionToasts, setCorrectionToasts] = useState<Record<string, "pending" | "saving" | "saved" | "dismissed">>({});
+  // corrections saved this session (for bulk pre-export review)
+  const [sessionCorrections, setSessionCorrections] = useState<SavedCorrection[]>([]);
+  const [showCorrectionsReview, setShowCorrectionsReview] = useState(false);
+  // per-field auto-dismiss timers
+  const correctionTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   // blur-based inline validation errors — fieldId → error message string
   const [blurErrors, setBlurErrors] = useState<Record<string, string>>({});
   // deterministic fix suggestions — fieldId → corrected value string
@@ -534,38 +540,69 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
   function handleFieldBlurForCorrection(fieldId: string, fieldLabel: string) {
     const currentValue = values[fieldId];
     const originalValue = originalAutofillValues.current[fieldId];
-    // Only prompt if: field was autofilled, value changed, toast not already shown/dismissed
+    const fieldDef = fields.find((f) => f.id === fieldId);
+    const confidence = fieldDef?.confidence ?? 0;
+    // Only prompt if: field was autofilled (confidence ≥ 0.5), value changed, toast not already shown/dismissed
     if (
       originalValue !== undefined &&
+      confidence >= 0.5 &&
       currentValue &&
       currentValue !== originalValue &&
       correctionToasts[fieldId] === undefined
     ) {
       setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "pending" }));
-      // Store label for the save action
+      // Store label + profileKey for the save action
       originalAutofillValues.current[`${fieldId}__label`] = fieldLabel;
+      // Auto-dismiss after 5 seconds if ignored
+      correctionTimers.current[fieldId] = setTimeout(() => {
+        setCorrectionToasts((prev) => {
+          if (prev[fieldId] === "pending") return { ...prev, [fieldId]: "dismissed" };
+          return prev;
+        });
+      }, 5000);
     }
   }
 
   function dismissCorrectionToast(fieldId: string) {
+    if (correctionTimers.current[fieldId]) {
+      clearTimeout(correctionTimers.current[fieldId]);
+      delete correctionTimers.current[fieldId];
+    }
     setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "dismissed" }));
   }
 
   async function saveCorrection(fieldId: string) {
     const fieldLabel = originalAutofillValues.current[`${fieldId}__label`] ?? "";
     const value = values[fieldId];
+    const originalValue = originalAutofillValues.current[fieldId] ?? "";
+    const fieldDef = fields.find((f) => f.id === fieldId);
+    const profileKey = fieldDef?.profileKey;
+
     if (!fieldLabel || !value) {
       dismissCorrectionToast(fieldId);
       return;
     }
+    if (correctionTimers.current[fieldId]) {
+      clearTimeout(correctionTimers.current[fieldId]);
+      delete correctionTimers.current[fieldId];
+    }
     setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "saving" }));
     try {
-      await fetch("/api/corrections", {
+      const res = await fetch("/api/profile/learn", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ fieldLabel, value }),
+        body: JSON.stringify({ fieldLabel, value, ...(profileKey ? { profileKey } : {}) }),
       });
+      const data = await res.json() as { success?: boolean; profileUpdated?: boolean };
       setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "saved" }));
+      // Track in session corrections for pre-export review
+      setSessionCorrections((prev) => {
+        const existing = prev.find((c) => c.fieldId === fieldId);
+        if (existing) {
+          return prev.map((c) => c.fieldId === fieldId ? { ...c, correctedValue: value, profileUpdated: data.profileUpdated ?? false } : c);
+        }
+        return [...prev, { fieldId, fieldLabel, originalValue, correctedValue: value, profileUpdated: data.profileUpdated ?? false }];
+      });
       setTimeout(() => {
         setCorrectionToasts((prev) => ({ ...prev, [fieldId]: "dismissed" }));
       }, 2000);
@@ -978,6 +1015,13 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
       setShowExportUpgradeModal(true);
       return;
     }
+
+    // Show corrections review summary before export if any corrections were saved
+    if (sessionCorrections.length > 0 && !showCorrectionsReview) {
+      setShowCorrectionsReview(true);
+      return;
+    }
+    setShowCorrectionsReview(false);
 
     // Run client-side validation first for instant feedback
     const result = validateForm(fields, values, fieldStates as Record<string, string>);
@@ -3159,6 +3203,14 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
           handleAutofill();
         }}
         onClose={() => setGapSlideOver(null)}
+      />
+    )}
+    {/* Corrections review — shown before export when corrections were saved this session */}
+    {showCorrectionsReview && (
+      <CorrectionsReviewModal
+        corrections={sessionCorrections}
+        onExport={() => handleExport()}
+        onClose={() => setShowCorrectionsReview(false)}
       />
     )}
     </>


### PR DESCRIPTION
## Summary
- Correction toast now **only triggers when autofill confidence ≥ 0.5** (previously fired for any autofilled field)
- Toast **auto-dismisses after 5 seconds** if ignored (previously required manual dismiss)
- "Save" now calls `POST /api/profile/learn` (new) which writes to **both** FormMemory (confidence=1.0, fieldType=correction) **and** the user's profile (via PATCH-style merge if the field has a `profileKey`)
- All corrections saved in a session are tracked client-side; a **pre-export corrections review modal** shows the list before download so users can confirm their changes

## New files
- `src/app/api/profile/learn/route.ts` — combined endpoint: FormMemory upsert + profile patch (if profileKey provided)
- `src/components/forms/CorrectionsReviewModal.tsx` — pre-export modal listing corrections with original→corrected values

## Test plan
- [ ] Autofill a form, then edit a field that was filled with ≥ 50% confidence
- [ ] Correction toast appears with "Save as preference?" — disappears after 5 seconds if ignored
- [ ] Clicking Save shows "Saving..." then "Saved as preference"
- [ ] If the field has a profileKey (e.g. phone), profile is updated in DB
- [ ] Editing a field filled with < 50% confidence does NOT show the toast
- [ ] Editing a field never autofilled does NOT show the toast
- [ ] Clicking Export after saving corrections shows the corrections review modal
- [ ] "Looks good — export" proceeds with download; "Go back" dismisses modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)