### PR TITLE
feat: deadline reminder milestones — 7d/2d/day-of per form (#424)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -275,12 +275,37 @@
 - Quota approaching warning (at 80% of free tier)
 - Form abandoned reminder (48h idle, with dismiss link)
 - Pro upgrade confirmation
+- Deadline reminder at 7 days, 2 days, and day-of (when due date is set)
 
 **Acceptance criteria:**
 - Each email renders correctly with user personalization
 - Quota email only sent once per billing period
 - Abandoned form email respects 7-day cooldown
 - All emails include unsubscribe/dismiss mechanism
+- Deadline reminder not sent for completed forms
+
+---
+
+### Form Deadline & Reminders
+
+**Description:** Users can attach an optional due date to any form. The due date is surfaced as a color-coded badge on dashboard form cards and triggers email reminders as the deadline approaches.
+
+**User flow:**
+1. User opens a form detail page
+2. User sets or changes a due date via the date picker (no past dates allowed)
+3. Dashboard shows deadline badge (green >7d, amber 2–7d, red <2d or overdue)
+4. Dashboard can be sorted by due date
+5. Email reminders sent at 7 days, 2 days, and day-of (each sent once per form)
+6. User can disable all reminders in Settings → Email Notifications
+
+**Acceptance criteria:**
+- `dueDate` field on Form model (nullable DateTime)
+- Date picker on form detail page; date saved via PATCH /api/forms/[id]
+- Dashboard badge is color-coded by urgency (green/amber/red)
+- Cron job at `/api/cron/deadline-reminders` runs daily; sends each milestone reminder exactly once per form
+- Reminder email includes form title, days until due, and "Resume filling" deep link
+- No reminder sent if form status is COMPLETED
+- User global toggle at Settings → "Deadline reminder emails"
 
 ---
 

--- a/src/app/api/cron/deadline-reminders/route.ts
+++ b/src/app/api/cron/deadline-reminders/route.ts
@@ -9,10 +9,9 @@ import { log } from "@/lib/logger";
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://getformpilot.com";
 const CRON_SECRET = process.env.CRON_SECRET ?? "";
 
-// Only remind within this window before due date
-const REMIND_WINDOW_DAYS = 7;
-// Don't send another reminder for the same form within this many days
-const COOLDOWN_DAYS = 3;
+// Reminder milestones in days-before-due. Three emails max per form per deadline.
+// Defined in descending order so we always send the most-advance applicable one first.
+const MILESTONES = [7, 2, 1]; // 7 days out, 2 days out, day-of (1)
 
 async function makeUnsubscribeUrl(userId: string): Promise<string> {
   const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET ?? CRON_SECRET);
@@ -23,6 +22,17 @@ async function makeUnsubscribeUrl(userId: string): Promise<string> {
   return `${APP_URL}/api/email/unsubscribe?token=${token}`;
 }
 
+// Determine which milestone to send for a form at `daysUntilDue`
+// Returns the lowest milestone bucket that hasn't been sent yet
+// e.g. 6 days away → 7-day bucket; 2 days away → 2-day bucket
+function getMilestoneBucket(daysUntilDue: number): number | null {
+  // Find the smallest milestone that is >= daysUntilDue (we're within that window)
+  for (const m of [...MILESTONES].reverse()) {
+    if (daysUntilDue <= m) return m;
+  }
+  return null;
+}
+
 export async function GET(req: NextRequest) {
   const authHeader = req.headers.get("authorization");
   if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
@@ -30,10 +40,10 @@ export async function GET(req: NextRequest) {
   }
 
   const now = new Date();
-  const windowEnd = new Date(now.getTime() + REMIND_WINDOW_DAYS * 24 * 60 * 60 * 1000);
-  const cooldownCutoff = new Date(now.getTime() - COOLDOWN_DAYS * 24 * 60 * 60 * 1000);
+  const maxMilestone = Math.max(...MILESTONES);
+  const windowEnd = new Date(now.getTime() + maxMilestone * 24 * 60 * 60 * 1000);
 
-  // Find all incomplete forms with a due date in the next 7 days
+  // Find all incomplete forms with a due date within the largest milestone window
   const forms = await prisma.form.findMany({
     where: {
       dueDate: { gte: now, lte: windowEnd },
@@ -59,18 +69,26 @@ export async function GET(req: NextRequest) {
       continue;
     }
 
-    // Check cooldown — skip if we already sent a reminder recently
-    const recentReminder = await prisma.formReminder.findFirst({
-      where: { formId: form.id, sentAt: { gte: cooldownCutoff } },
-    });
-    if (recentReminder) {
+    const dueDate = form.dueDate!;
+    const msUntilDue = dueDate.getTime() - now.getTime();
+    const daysUntilDue = Math.ceil(msUntilDue / (24 * 60 * 60 * 1000));
+
+    // Determine which milestone bucket we're in
+    const bucket = getMilestoneBucket(daysUntilDue);
+    if (bucket === null) {
       skipped++;
       continue;
     }
 
-    const dueDate = form.dueDate!;
-    const msUntilDue = dueDate.getTime() - now.getTime();
-    const daysUntilDue = Math.ceil(msUntilDue / (24 * 60 * 60 * 1000));
+    // Skip if we already sent a reminder at or below this bucket
+    const alreadySent = await prisma.formReminder.findFirst({
+      where: { formId: form.id, daysBeforeDue: { lte: bucket } },
+    });
+    if (alreadySent) {
+      skipped++;
+      continue;
+    }
+
     const dueDateFormatted = dueDate.toLocaleDateString("en-US", {
       month: "long",
       day: "numeric",
@@ -79,11 +97,15 @@ export async function GET(req: NextRequest) {
 
     try {
       const unsubscribeUrl = await makeUnsubscribeUrl(form.userId);
+      const subject = daysUntilDue <= 1
+        ? `⚠️ "${form.title}" is due today`
+        : daysUntilDue <= 2
+          ? `⏰ "${form.title}" is due in 2 days`
+          : `"${form.title}" is due in ${daysUntilDue} days`;
+
       await sendEmail(
         form.user.email,
-        daysUntilDue <= 1
-          ? `⚠️ "${form.title}" is due tomorrow`
-          : `"${form.title}" is due in ${daysUntilDue} days`,
+        subject,
         React.createElement(DeadlineReminderEmail, {
           formTitle: form.title,
           formId: form.id,
@@ -95,7 +117,7 @@ export async function GET(req: NextRequest) {
       );
 
       await prisma.formReminder.create({
-        data: { formId: form.id, userId: form.userId, daysBeforeDue: daysUntilDue },
+        data: { formId: form.id, userId: form.userId, daysBeforeDue: bucket },
       });
       sent++;
     } catch (err) {


### PR DESCRIPTION
## Summary
Most of #424 was already implemented (dueDate field, date picker UI, dashboard badge, cron, email template, settings toggle). This PR completes the acceptance criteria:

- **Milestone-based reminder sending**: replaced the 3-day cooldown approach with a bucket system (7d / 2d / day-of). Each form now receives at most 3 reminder emails, one per milestone. Skips if a reminder at or below that bucket was already sent.
- **PRODUCT.md**: documented the deadline reminder feature (user flow, acceptance criteria)

## Changed files
- `src/app/api/cron/deadline-reminders/route.ts` — milestone buckets, `getMilestoneBucket()` helper, improved email subjects
- `PRODUCT.md` — deadline reminder feature section added

## Test plan
- [ ] Form with dueDate 8 days out: no email (outside 7-day window)
- [ ] Form with dueDate 6 days out: 7-day bucket email sent; subsequent run skips
- [ ] Form with dueDate 2 days out: 2-day bucket email sent; if 7-day was already sent, skips that
- [ ] Form with dueDate tomorrow: day-of email sent
- [ ] COMPLETED form: no email regardless of due date
- [ ] User with reminderEmailsEnabled=false: no email

🤖 Generated with [Claude Code](https://claude.com/claude-code)