### PR TITLE
feat: extract pre-filled values from uploaded PDF AcroForm fields (#426)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -80,6 +80,8 @@
 - Confidence scores displayed per field (green/yellow/red)
 - User can accept/reject each autofilled value
 - Autofill respects rate limit (20 requests/user/hour)
+- If the uploaded PDF contains pre-existing AcroForm field values, those are automatically pre-populated at upload time (confidence 95%, badge: "From document")
+- If no AcroForm metadata exists (flat/image PDF), the step is silently skipped
 
 ---
 

--- a/src/__tests__/extract-acroform.test.ts
+++ b/src/__tests__/extract-acroform.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for extractAcroFormValues
+ * Tests that AcroForm field values are correctly read from a PDF.
+ */
+
+import { PDFDocument, PDFTextField } from "pdf-lib";
+import { extractAcroFormValues } from "@/lib/pdf/extract";
+
+/** Build a minimal PDF buffer with AcroForm text fields. */
+async function buildPDFWithFields(
+  fields: Array<{ name: string; value: string }>
+): Promise<Buffer> {
+  const pdfDoc = await PDFDocument.create();
+  pdfDoc.addPage();
+  const form = pdfDoc.getForm();
+  for (const { name, value } of fields) {
+    const field = form.createTextField(name);
+    field.setText(value);
+  }
+  const bytes = await pdfDoc.save();
+  return Buffer.from(bytes);
+}
+
+/** Build a minimal flat PDF with no AcroForm. */
+async function buildFlatPDF(): Promise<Buffer> {
+  const pdfDoc = await PDFDocument.create();
+  pdfDoc.addPage();
+  const bytes = await pdfDoc.save();
+  return Buffer.from(bytes);
+}
+
+describe("extractAcroFormValues", () => {
+  it("extracts text field values from a PDF with AcroForm fields", async () => {
+    const buf = await buildPDFWithFields([
+      { name: "FirstName", value: "Alice" },
+      { name: "LastName", value: "Wong" },
+      { name: "Email", value: "alice@example.com" },
+    ]);
+
+    const values = await extractAcroFormValues(buf);
+
+    expect(values["FirstName"]).toBe("Alice");
+    expect(values["LastName"]).toBe("Wong");
+    expect(values["Email"]).toBe("alice@example.com");
+  });
+
+  it("returns empty object for a flat PDF with no AcroForm", async () => {
+    const buf = await buildFlatPDF();
+    const values = await extractAcroFormValues(buf);
+    expect(values).toEqual({});
+  });
+
+  it("omits fields with empty values", async () => {
+    const buf = await buildPDFWithFields([
+      { name: "FilledField", value: "Hello" },
+      { name: "EmptyField", value: "" },
+    ]);
+
+    const values = await extractAcroFormValues(buf);
+
+    expect(values["FilledField"]).toBe("Hello");
+    expect("EmptyField" in values).toBe(false);
+  });
+
+  it("returns empty object for an invalid buffer without throwing", async () => {
+    const garbage = Buffer.from("this is not a pdf");
+    const values = await extractAcroFormValues(garbage);
+    expect(values).toEqual({});
+  });
+
+  it("trims whitespace from extracted values", async () => {
+    const buf = await buildPDFWithFields([
+      { name: "City", value: "  New York  " },
+    ]);
+
+    const values = await extractAcroFormValues(buf);
+    expect(values["City"]).toBe("New York");
+  });
+});

--- a/src/app/api/forms/upload/route.ts
+++ b/src/app/api/forms/upload/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { canUploadForm, incrementFormUsage, isProUser } from "@/lib/subscription";
 import { grantReferralBonus } from "@/lib/referral";
-import { extractTextFromBuffer, getPDFPageCount } from "@/lib/pdf/extract";
+import { extractTextFromBuffer, getPDFPageCount, extractAcroFormValues } from "@/lib/pdf/extract";
 import { analyzeFormFields, analyzeFormFieldsFromImage } from "@/lib/ai/analyze-form";
 import { preprocessImage } from "@/lib/image/preprocess";
 import { checkRateLimit, checkIpRateLimit } from "@/lib/rate-limit";
@@ -209,6 +209,41 @@ export async function POST(req: NextRequest) {
       );
     }
     return handleApiError(err, "POST /api/forms/upload");
+  }
+
+  // For PDF uploads: extract any pre-existing AcroForm field values and merge them into
+  // the AI-analysed fields. Normalised name matching (strip non-alphanumeric, lowercase).
+  if (sourceType === "PDF") {
+    const acroValues = await extractAcroFormValues(buffer);
+    if (Object.keys(acroValues).length > 0) {
+      const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+      const acroNorm: Record<string, string> = {};
+      for (const [k, v] of Object.entries(acroValues)) {
+        acroNorm[normalize(k)] = v;
+      }
+      analysis.fields = analysis.fields.map((field) => {
+        // Skip fields that already have a value (from profile autofill applied earlier)
+        if (field.value) return field;
+        const labelNorm = normalize(field.label);
+        // Try exact match, then check if label contains the acro key or vice-versa
+        let matched: string | undefined;
+        for (const [normKey, val] of Object.entries(acroNorm)) {
+          if (normKey === labelNorm || (normKey.length >= 4 && labelNorm.includes(normKey)) || (labelNorm.length >= 4 && normKey.includes(labelNorm))) {
+            matched = val;
+            break;
+          }
+        }
+        if (matched) {
+          return { ...field, value: matched, confidence: 0.95, matchedFrom: "document" as const };
+        }
+        return field;
+      });
+      log.info("AcroForm values merged", {
+        route: "POST /api/forms/upload",
+        acroFieldCount: Object.keys(acroValues).length,
+        mergedCount: analysis.fields.filter((f) => f.matchedFrom === "document").length,
+      });
+    }
   }
 
   try {

--- a/src/components/forms/FormViewer.tsx
+++ b/src/components/forms/FormViewer.tsx
@@ -2222,6 +2222,19 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
         />
       )}
 
+      {/* Document pre-fill banner — shown when the uploaded PDF had existing AcroForm values */}
+      {fields.some((f) => f.matchedFrom === "document") && (
+        <div className="flex items-center gap-2.5 px-4 py-2.5 bg-blue-50 border border-blue-100 rounded-xl text-sm text-blue-700">
+          <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            <line x1="16" y1="13" x2="8" y2="13" />
+            <line x1="16" y1="17" x2="8" y2="17" />
+          </svg>
+          This form was already partially filled — {fields.filter((f) => f.matchedFrom === "document").length} field{fields.filter((f) => f.matchedFrom === "document").length !== 1 ? "s" : ""} pre-populated from the document. Review and confirm before exporting.
+        </div>
+      )}
+
       {/* Prior fill banner — shown when form was pre-filled from a previous submission */}
       {fields.some((f) => f.matchedFrom === "prior_fill") && (
         <div className="flex items-center gap-2.5 px-4 py-2.5 bg-violet-50 border border-violet-100 rounded-xl text-sm text-violet-700">
@@ -2604,6 +2617,15 @@ export default function FormViewer({ form, hasProfile, onFieldFocus, onValueChan
                       {state === "rejected" && (
                         <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-slate-100 text-slate-500">
                           Skipped
+                        </span>
+                      )}
+                      {field.matchedFrom === "document" && state !== "accepted" && state !== "rejected" && (
+                        <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 text-blue-700">
+                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                            <polyline points="14 2 14 8 20 8" />
+                          </svg>
+                          From document
                         </span>
                       )}
                       {field.matchedFrom === "prior_fill" && state !== "accepted" && state !== "rejected" && (

--- a/src/lib/ai/analyze-form.ts
+++ b/src/lib/ai/analyze-form.ts
@@ -68,7 +68,8 @@ export interface FormField {
   /** Optional bounding box from PDF analysis (0–1 fractions of page size). */
   coordinates?: FieldCoordinates;
   /** Set to "prior_fill" when value was mapped from a previous form submission. */
-  matchedFrom?: "prior_fill";
+  /** Set to "document" when value was extracted from the PDF's own AcroForm fields. */
+  matchedFrom?: "prior_fill" | "document";
 }
 
 export interface FormAnalysis {

--- a/src/lib/pdf/extract.ts
+++ b/src/lib/pdf/extract.ts
@@ -1,9 +1,45 @@
 import pdfParse from "pdf-parse";
 import mammoth from "mammoth";
+import { PDFDocument, PDFTextField, PDFCheckBox, PDFDropdown, PDFRadioGroup } from "pdf-lib";
 
 export async function extractTextFromPDF(buffer: Buffer): Promise<string> {
   const data = await pdfParse(buffer);
   return data.text;
+}
+
+/**
+ * Extract existing AcroForm field values from a PDF.
+ * Returns a map of normalised field name → value for any fields that have a non-empty value.
+ * If the PDF has no AcroForm structure, returns an empty map (never throws).
+ */
+export async function extractAcroFormValues(buffer: Buffer): Promise<Record<string, string>> {
+  try {
+    const pdfDoc = await PDFDocument.load(buffer, { ignoreEncryption: true });
+    const form = pdfDoc.getForm();
+    const pdfFields = form.getFields();
+    const result: Record<string, string> = {};
+    for (const field of pdfFields) {
+      const name = field.getName();
+      let value: string | undefined;
+      if (field instanceof PDFTextField) {
+        const text = field.getText();
+        if (text && text.trim()) value = text.trim();
+      } else if (field instanceof PDFCheckBox) {
+        if (field.isChecked()) value = "Checked";
+      } else if (field instanceof PDFDropdown) {
+        const selected = field.getSelected();
+        if (selected.length > 0 && selected[0].trim()) value = selected[0].trim();
+      } else if (field instanceof PDFRadioGroup) {
+        const selected = field.getSelected();
+        if (selected && selected.trim()) value = selected.trim();
+      }
+      if (value) result[name] = value;
+    }
+    return result;
+  } catch {
+    // PDF has no AcroForm, is encrypted, or parsing failed — silently return empty
+    return {};
+  }
 }
 
 export async function getPDFPageCount(buffer: Buffer): Promise<number> {


### PR DESCRIPTION
## Summary
- When a PDF is uploaded, `extractAcroFormValues()` reads any existing AcroForm field values via `pdf-lib`
- Matched fields are pre-populated with the document value, confidence 0.95, and `matchedFrom: "document"`
- Normalised name matching (strip non-alphanumeric, lowercase) maps AcroForm field names to AI-extracted labels
- "From document" banner + per-field badge shown in FormViewer (neutral blue, distinct from "Prior fill" violet)
- Flat / image-based PDFs with no AcroForm silently return empty — no error shown

## Test plan
- [ ] Upload a fillable PDF that has pre-existing values (e.g. a W-4 with name pre-typed)
- [ ] Fields with AcroForm values are pre-populated on the form detail page
- [ ] Blue "From document" banner appears at the top of the field list
- [ ] Each matched field shows a "From document" badge
- [ ] Fields with confidence 0.95 show correctly in the confidence bar
- [ ] Upload a flat / scanned PDF — no error, fields are empty as normal
- [ ] All 5 unit tests pass: `npx jest src/__tests__/extract-acroform.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)